### PR TITLE
Add McGraw Hill Connect support via slot-graph contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## Usage
 
-1. Log into your McGraw Hill account and open a Smartbook assignment
+1. Log into your McGraw Hill account and open a Smartbook or Connect assignment
 2. Log into one of the supported AI assistants in another tab:
    - [ChatGPT](https://chatgpt.com)
    - [Gemini](https://gemini.google.com)

--- a/background/background.js
+++ b/background/background.js
@@ -14,8 +14,13 @@ let pendingResponse = null;
 const MHE_URL_PATTERNS = [
   "https://learning.mheducation.com/*",
   "https://ezto.mheducation.com/*",
+  "https://newconnect.mheducation.com/*",
 ];
-const MHE_HOSTS = ["learning.mheducation.com", "ezto.mheducation.com"];
+const MHE_HOSTS = [
+  "learning.mheducation.com",
+  "ezto.mheducation.com",
+  "newconnect.mheducation.com",
+];
 const AI_MODELS = {
   chatgpt: {
     tabQuery: { url: "https://chatgpt.com/*" },

--- a/background/background.js
+++ b/background/background.js
@@ -10,12 +10,48 @@ let originalTabId = null;
 let storedResponse = null;
 let isProcessingDuplicate = false;
 let pendingResponse = null;
-const DEEPSEEK_URL_PATTERNS = [
-  "https://chat.deepseek.com/*",
-];
 
-function isDeepSeekTabUrl(url = "") {
-  return url.includes("chat.deepseek.com") || url.includes("deepseek.chat");
+const MHE_URL_PATTERNS = [
+  "https://learning.mheducation.com/*",
+  "https://ezto.mheducation.com/*",
+];
+const MHE_HOSTS = ["learning.mheducation.com", "ezto.mheducation.com"];
+const AI_MODELS = {
+  chatgpt: {
+    tabQuery: { url: "https://chatgpt.com/*" },
+    hosts: ["chatgpt.com"],
+  },
+  gemini: {
+    tabQuery: { url: "https://gemini.google.com/*" },
+    hosts: ["gemini.google.com"],
+  },
+  deepseek: {
+    tabQuery: { url: ["https://chat.deepseek.com/*"] },
+    hosts: ["chat.deepseek.com"],
+  },
+};
+const AI_RESPONSE_MODEL_BY_MESSAGE_TYPE = {
+  chatGPTResponse: "chatgpt",
+  geminiResponse: "gemini",
+  deepseekResponse: "deepseek",
+};
+
+function isMheTabUrl(url = "") {
+  return MHE_HOSTS.some((host) => url.includes(host));
+}
+
+function getAiModelForUrl(url = "") {
+  return (
+    Object.entries(AI_MODELS).find(([, config]) =>
+      config.hosts.some((host) => url.includes(host)),
+    )?.[0] || null
+  );
+}
+
+function resolveAiModel(preferredModel, storedModel) {
+  if (AI_MODELS[preferredModel]) return preferredModel;
+  if (AI_MODELS[storedModel]) return storedModel;
+  return "chatgpt";
 }
 
 chrome.tabs.onActivated.addListener((activeInfo) => {
@@ -64,58 +100,32 @@ async function focusTab(tabId) {
   }
 }
 
-async function findAndStoreTabs() {
-  const mheTabs = await chrome.tabs.query({
-    url: [
-      "https://learning.mheducation.com/*",
-      "https://ezto.mheducation.com/*",
-    ],
-  });
+async function findAndStoreTabs(preferredModel = null) {
+  const mheTabs = await chrome.tabs.query({ url: MHE_URL_PATTERNS });
   if (mheTabs.length > 0) {
-    mheTabId = mheTabs[0].id;
-    mheWindowId = mheTabs[0].windowId;
+    const preferredMheTab =
+      mheTabs.find((tab) => tab.id === mheTabId) || mheTabs[0];
+    mheTabId = preferredMheTab.id;
+    mheWindowId = preferredMheTab.windowId;
   }
 
   const data = await chrome.storage.sync.get("aiModel");
-  const aiModel = data.aiModel || "chatgpt";
+  const aiModel = resolveAiModel(preferredModel, data.aiModel);
   aiType = aiModel;
 
-  if (aiModel === "chatgpt") {
-    const tabs = await chrome.tabs.query({ url: "https://chatgpt.com/*" });
-    if (tabs.length > 0) {
-      aiTabId = tabs[0].id;
-      aiWindowId = tabs[0].windowId;
-    } else {
-      aiTabId = null;
-    }
-  } else if (aiModel === "gemini") {
-    const tabs = await chrome.tabs.query({
-      url: "https://gemini.google.com/*",
-    });
-    if (tabs.length > 0) {
-      aiTabId = tabs[0].id;
-      aiWindowId = tabs[0].windowId;
-    } else {
-      aiTabId = null;
-    }
-  } else if (aiModel === "deepseek") {
-    const tabs = await chrome.tabs.query({
-      url: DEEPSEEK_URL_PATTERNS,
-    });
-    if (tabs.length > 0) {
-      const preferredTab =
-        tabs.find((tab) => tab.url && tab.url.includes("chat.deepseek.com")) ||
-        tabs[0];
-      aiTabId = preferredTab.id;
-      aiWindowId = preferredTab.windowId;
-    } else {
-      aiTabId = null;
-    }
+  const aiModelConfig = AI_MODELS[aiModel];
+  const aiTabs = await chrome.tabs.query(aiModelConfig.tabQuery);
+  if (aiTabs.length > 0) {
+    aiTabId = aiTabs[0].id;
+    aiWindowId = aiTabs[0].windowId;
+  } else {
+    aiTabId = null;
+    aiWindowId = null;
   }
 }
 
-async function shouldFocusTabs() {
-  await findAndStoreTabs();
+async function shouldFocusTabs(preferredModel = null) {
+  await findAndStoreTabs(preferredModel);
   return mheWindowId === aiWindowId;
 }
 
@@ -124,7 +134,7 @@ async function processQuestion(message) {
   processingQuestion = true;
 
   try {
-    await findAndStoreTabs();
+    await findAndStoreTabs(message.aiModel);
 
     if (!aiTabId) {
       await sendMessageWithRetry(mheTabId, {
@@ -142,7 +152,7 @@ async function processQuestion(message) {
       mheTabId = message.sourceTabId;
     }
 
-    const sameWindow = await shouldFocusTabs();
+    const sameWindow = await shouldFocusTabs(message.aiModel);
 
     if (sameWindow) {
       await focusTab(aiTabId);
@@ -198,12 +208,7 @@ async function processResponse(message) {
     }
 
     if (!mheTabId) {
-      const mheTabs = await chrome.tabs.query({
-        url: [
-          "https://learning.mheducation.com/*",
-          "https://ezto.mheducation.com/*",
-        ],
-      });
+      const mheTabs = await chrome.tabs.query({ url: MHE_URL_PATTERNS });
       if (mheTabs.length > 0) {
         mheTabId = mheTabs[0].id;
         mheWindowId = mheTabs[0].windowId;
@@ -212,7 +217,9 @@ async function processResponse(message) {
       }
     }
 
-    const sameWindow = await shouldFocusTabs();
+    const responseModel =
+      AI_RESPONSE_MODEL_BY_MESSAGE_TYPE[message.type] || null;
+    const sameWindow = await shouldFocusTabs(responseModel);
 
     if (sameWindow) {
       await focusTab(mheTabId);
@@ -226,6 +233,39 @@ async function processResponse(message) {
   } catch (error) {
     console.error("Error processing AI response:", error);
   }
+}
+
+async function processAiResponseTimeout(message) {
+  try {
+    if (!mheTabId) {
+      await findAndStoreTabs(message.aiModel);
+    }
+
+    if (!mheTabId) return;
+
+    await sendMessageWithRetry(mheTabId, {
+      type: "stopAutomation",
+      reason:
+        message.reason ||
+        "AI did not produce a response before the automation timeout.",
+    });
+  } catch (error) {}
+}
+
+async function cancelAiResponseTimeout(message) {
+  try {
+    if (!aiTabId) {
+      await findAndStoreTabs(message?.aiModel);
+    }
+    if (!aiTabId) return;
+
+    await sendMessageWithRetry(
+      aiTabId,
+      { type: "cancelResponseObservation" },
+      1,
+      300,
+    );
+  } catch (error) {}
 }
 
 async function waitForTabReady(tabId, maxAttempts = 8) {
@@ -252,26 +292,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (sender.tab) {
     message.sourceTabId = sender.tab.id;
 
-    if (
-      sender.tab.url.includes("learning.mheducation.com") ||
-      sender.tab.url.includes("ezto.mheducation.com")
-    ) {
+    const senderUrl = sender.tab.url || "";
+    const senderAiModel = getAiModelForUrl(senderUrl);
+
+    if (isMheTabUrl(senderUrl)) {
       if (!originalTabId && !duplicateTabId) {
         mheTabId = sender.tab.id;
         mheWindowId = sender.tab.windowId;
       }
-    } else if (sender.tab.url.includes("chatgpt.com")) {
+    } else if (senderAiModel) {
       aiTabId = sender.tab.id;
       aiWindowId = sender.tab.windowId;
-      aiType = "chatgpt";
-    } else if (sender.tab.url.includes("gemini.google.com")) {
-      aiTabId = sender.tab.id;
-      aiWindowId = sender.tab.windowId;
-      aiType = "gemini";
-    } else if (isDeepSeekTabUrl(sender.tab.url || "")) {
-      aiTabId = sender.tab.id;
-      aiWindowId = sender.tab.windowId;
-      aiType = "deepseek";
+      aiType = senderAiModel;
     }
   }
 
@@ -292,6 +324,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     message.type === "deepseekResponse"
   ) {
     processResponse(message);
+    sendResponse({ received: true });
+    return true;
+  }
+
+  if (message.type === "aiResponseTimeout") {
+    processAiResponseTimeout(message);
+    sendResponse({ received: true });
+    return true;
+  }
+
+  if (message.type === "cancelAiResponseTimeout") {
+    cancelAiResponseTimeout(message);
     sendResponse({ received: true });
     return true;
   }

--- a/content-scripts/chatgpt.js
+++ b/content-scripts/chatgpt.js
@@ -2,9 +2,26 @@ let hasResponded = false;
 let messageCountAtQuestion = 0;
 let observationStartTime = 0;
 let observationTimeout = null;
+let observationInterval = null;
 let observer = null;
+let responseInFlight = false;
+let lastSentResponseText = "";
+let assistantTextAtQuestion = "";
+let pendingCandidateText = "";
+let pendingCandidateSeenAt = 0;
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === "ping") {
+    sendResponse({ received: true });
+    return true;
+  }
+
+  if (message.type === "cancelResponseObservation") {
+    resetObservation();
+    sendResponse({ received: true });
+    return true;
+  }
+
   if (message.type === "receiveQuestion") {
     resetObservation();
 
@@ -12,6 +29,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       '[data-message-author-role="assistant"]'
     );
     messageCountAtQuestion = messages.length;
+    assistantTextAtQuestion = getLatestAssistantResponseText();
     hasResponded = false;
 
     insertQuestion(message.question)
@@ -28,9 +46,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 function resetObservation() {
   hasResponded = false;
+  responseInFlight = false;
+  observationStartTime = 0;
+  pendingCandidateText = "";
+  pendingCandidateSeenAt = 0;
   if (observationTimeout) {
     clearTimeout(observationTimeout);
     observationTimeout = null;
+  }
+  if (observationInterval) {
+    clearInterval(observationInterval);
+    observationInterval = null;
   }
   if (observer) {
     observer.disconnect();
@@ -39,68 +65,88 @@ function resetObservation() {
 }
 
 async function insertQuestion(questionData) {
-  const { type, question, options, previousCorrection } = questionData;
-  let text = `Type: ${type}\nQuestion: ${question}`;
+  const text = buildPrompt(questionData);
+  const inputArea = await waitForChatInput();
 
-  if (
-    previousCorrection &&
-    previousCorrection.question &&
-    previousCorrection.correctAnswer
-  ) {
-    text =
-      `CORRECTION FROM PREVIOUS ANSWER: For the question "${
-        previousCorrection.question
-      }", your answer was incorrect. The correct answer was: ${JSON.stringify(
-        previousCorrection.correctAnswer
-      )}\n\nNow answer this new question:\n\n` + text;
+  inputArea.focus();
+
+  if ("value" in inputArea) {
+    inputArea.value = text;
+    inputArea.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        inputType: "insertText",
+        data: text,
+      })
+    );
+  } else {
+    inputArea.textContent = "";
+    const inserted = document.execCommand("insertText", false, text);
+    if (!inserted) {
+      inputArea.textContent = text;
+    }
+    inputArea.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        inputType: "insertText",
+        data: text,
+      })
+    );
   }
 
-  if (type === "matching") {
-    text +=
-      "\nPrompts:\n" +
-      options.prompts.map((prompt, i) => `${i + 1}. ${prompt}`).join("\n");
-    text +=
-      "\nChoices:\n" +
-      options.choices.map((choice, i) => `${i + 1}. ${choice}`).join("\n");
-    text +=
-      '\n\nPlease match each prompt with the correct choice. Set "answer" to an array of strings using the exact format \'Prompt -> Choice\'. Include one entry per prompt, use exact prompt and choice text, and use each choice at most once.';
-  } else if (type === "fill_in_the_blank") {
-    text +=
-      "\n\nThis is a fill in the blank question. If there are multiple blanks, provide answers as an array in order of appearance. For a single blank, you can provide a string.";
-  } else if (options && options.length > 0) {
-    text +=
-      "\nOptions:\n" + options.map((opt, i) => `${i + 1}. ${opt}`).join("\n");
-    text +=
-      "\n\nIMPORTANT: Your answer must EXACTLY match one of the above options. Do not include numbers in your answer. If there are periods, include them.";
-  }
+  inputArea.dispatchEvent(new Event("change", { bubbles: true }));
 
-  text +=
-    '\n\nPlease provide your answer in JSON format with keys "answer" and "explanation". Explanations should be no more than one sentence. DO NOT acknowledge the correction in your response, only answer the new question.';
+  const sendButton = await waitForSendButton();
+  sendButton.click();
+  startObserving();
+}
+
+function waitForChatInput(timeout = 15000) {
+  return waitForElement(
+    [
+      "#prompt-textarea",
+      '[contenteditable="true"][data-lexical-editor="true"]',
+      'textarea[data-testid="prompt-textarea"]',
+      "textarea",
+    ],
+    timeout,
+    (element) => !element.disabled && !element.getAttribute("aria-disabled")
+  );
+}
+
+function waitForSendButton(timeout = 10000) {
+  return waitForElement(
+    [
+      '[data-testid="send-button"]',
+      'button[aria-label="Send prompt"]',
+      'button[aria-label="Send message"]',
+      'button[data-testid="fruitjuice-send-button"]',
+    ],
+    timeout,
+    (element) =>
+      !element.disabled && element.getAttribute("aria-disabled") !== "true"
+  );
+}
+
+function waitForElement(selectors, timeout, predicate = () => true) {
+  const startedAt = Date.now();
 
   return new Promise((resolve, reject) => {
-    const inputArea = document.getElementById("prompt-textarea");
-    if (inputArea) {
-      setTimeout(() => {
-        inputArea.focus();
-        inputArea.innerHTML = `<p>${text}</p>`;
-        inputArea.dispatchEvent(new Event("input", { bubbles: true }));
+    const interval = setInterval(() => {
+      for (const selector of selectors) {
+        const element = document.querySelector(selector);
+        if (element && predicate(element)) {
+          clearInterval(interval);
+          resolve(element);
+          return;
+        }
+      }
 
-        setTimeout(() => {
-          const sendButton = document.querySelector(
-            '[data-testid="send-button"]'
-          );
-          if (sendButton) {
-            sendButton.click();
-            startObserving();
-            resolve();
-          } else {
-            reject(new Error("Send button not found"));
-          }
-        }, 300);
-      }, 300);
-    } else {
-      reject(new Error("Input area not found"));
-    }
+      if (Date.now() - startedAt > timeout) {
+        clearInterval(interval);
+        reject(new Error(`Element not found: ${selectors.join(", ")}`));
+      }
+    }, 150);
   });
 }
 
@@ -108,78 +154,17 @@ function startObserving() {
   observationStartTime = Date.now();
   observationTimeout = setTimeout(() => {
     if (!hasResponded) {
+      notifyAiResponseTimeout();
       resetObservation();
     }
   }, 180000);
 
-  observer = new MutationObserver((mutations) => {
-    if (hasResponded) return;
+  observationInterval = setInterval(() => {
+    tryCaptureLatestResponse();
+  }, 1000);
 
-    const messages = document.querySelectorAll(
-      '[data-message-author-role="assistant"]'
-    );
-    if (!messages.length) return;
-
-    if (messages.length <= messageCountAtQuestion) return;
-
-    const latestMessage = messages[messages.length - 1];
-    const codeBlocks = latestMessage.querySelectorAll("pre code");
-    let responseText = "";
-
-    for (const block of codeBlocks) {
-      if (block.className.includes("language-json")) {
-        responseText = block.textContent.trim();
-        break;
-      }
-    }
-
-    if (!responseText) {
-      responseText = latestMessage.textContent.trim();
-      const jsonMatch = responseText.match(/\{[\s\S]*\}/);
-      if (jsonMatch) responseText = jsonMatch[0];
-    }
-
-    responseText = responseText
-      .replace(/[\u200B-\u200D\uFEFF]/g, "")
-      .replace(/\n\s*/g, " ")
-      .trim();
-
-    try {
-      const parsed = JSON.parse(responseText);
-      if (parsed.answer && !hasResponded) {
-        hasResponded = true;
-        chrome.runtime
-          .sendMessage({
-            type: "chatGPTResponse",
-            response: responseText,
-          })
-          .then(() => {
-            resetObservation();
-          })
-          .catch((error) => {
-            console.error("Error sending response:", error);
-          });
-      }
-    } catch (e) {
-      const isGenerating = latestMessage.querySelector(".result-streaming");
-      if (!isGenerating && Date.now() - observationStartTime > 30000) {
-        const responseText = latestMessage.textContent.trim();
-        try {
-          const jsonPattern =
-            /\{[\s\S]*?"answer"[\s\S]*?"explanation"[\s\S]*?\}/;
-          const jsonMatch = responseText.match(jsonPattern);
-
-          if (jsonMatch && !hasResponded) {
-            hasResponded = true;
-            chrome.runtime.sendMessage({
-              type: "chatGPTResponse",
-              response: jsonMatch[0],
-            });
-            resetObservation();
-          }
-        } catch (e) {}
-      }
-    }
+  observer = new MutationObserver(() => {
+    tryCaptureLatestResponse();
   });
 
   observer.observe(document.body, {
@@ -188,3 +173,137 @@ function startObserving() {
     characterData: true,
   });
 }
+
+function tryCaptureLatestResponse() {
+  if (responseInFlight || !observationStartTime) return;
+
+  const messages = document.querySelectorAll(
+    '[data-message-author-role="assistant"]'
+  );
+  if (messages.length <= messageCountAtQuestion) return;
+
+  const latestMessage = messages[messages.length - 1];
+  if (isResponseStillGenerating(latestMessage)) return;
+
+  const responseText = extractJsonText(latestMessage);
+  if (
+    !responseText ||
+    responseText === lastSentResponseText ||
+    responseText === assistantTextAtQuestion
+  ) {
+    return;
+  }
+
+  if (responseText !== pendingCandidateText) {
+    pendingCandidateText = responseText;
+    pendingCandidateSeenAt = Date.now();
+    return;
+  }
+
+  if (Date.now() - pendingCandidateSeenAt < 600) {
+    return;
+  }
+
+  try {
+    const parsed = JSON.parse(responseText);
+    if (parsed.answer !== undefined || parsed.slots) {
+      responseInFlight = true;
+      hasResponded = true;
+      chrome.runtime
+        .sendMessage({
+          type: "chatGPTResponse",
+          response: responseText,
+        })
+        .then(() => {
+          lastSentResponseText = responseText;
+          resetObservation();
+        })
+        .catch((error) => {
+          responseInFlight = false;
+          hasResponded = false;
+          console.error("Error sending response:", error);
+        });
+    }
+  } catch (error) {
+    if (Date.now() - observationStartTime > 30000) {
+      const fallback = findJsonObject(latestMessage.textContent.trim());
+      if (
+        !fallback ||
+        fallback === lastSentResponseText ||
+        fallback === assistantTextAtQuestion
+      ) {
+        return;
+      }
+      let fallbackParsed;
+      try {
+        fallbackParsed = JSON.parse(fallback);
+      } catch (_) {
+        return;
+      }
+      if (fallbackParsed.answer === undefined && !fallbackParsed.slots) {
+        return;
+      }
+      responseInFlight = true;
+      hasResponded = true;
+      chrome.runtime
+        .sendMessage({
+          type: "chatGPTResponse",
+          response: fallback,
+        })
+        .then(() => {
+          lastSentResponseText = fallback;
+          resetObservation();
+        })
+        .catch((sendError) => {
+          responseInFlight = false;
+          hasResponded = false;
+          console.error("Error sending fallback response:", sendError);
+        });
+    }
+  }
+}
+
+function notifyAiResponseTimeout() {
+  try {
+    chrome.runtime.sendMessage({
+      type: "aiResponseTimeout",
+      aiModel: "chatgpt",
+      reason: "ChatGPT did not produce a response within 180 seconds.",
+    });
+  } catch (error) {
+    console.error("Error notifying timeout:", error);
+  }
+}
+
+function isResponseStillGenerating(message) {
+  return Boolean(
+    document.querySelector('[data-testid="stop-button"]') ||
+      message.querySelector(".result-streaming") ||
+      message
+        .closest('[data-message-author-role="assistant"]')
+        ?.querySelector('[aria-label*="Stop"], [data-testid*="stop"]')
+  );
+}
+
+function getLatestAssistantResponseText() {
+  const messages = document.querySelectorAll(
+    '[data-message-author-role="assistant"]'
+  );
+  if (!messages.length) return "";
+
+  const latestMessage = messages[messages.length - 1];
+  return extractJsonText(latestMessage);
+}
+
+function extractJsonText(message) {
+  const codeBlocks = message.querySelectorAll("pre code");
+
+  for (const block of codeBlocks) {
+    const text = sanitizeResponseText(block.textContent);
+    if (looksLikeJsonResponse(text)) return text;
+  }
+
+  const text = sanitizeResponseText(message.textContent);
+  return findJsonObject(text);
+}
+

--- a/content-scripts/chatgpt.js
+++ b/content-scripts/chatgpt.js
@@ -2,7 +2,6 @@ let hasResponded = false;
 let messageCountAtQuestion = 0;
 let observationStartTime = 0;
 let observationTimeout = null;
-let observationInterval = null;
 let observer = null;
 let responseInFlight = false;
 let lastSentResponseText = "";
@@ -53,10 +52,6 @@ function resetObservation() {
   if (observationTimeout) {
     clearTimeout(observationTimeout);
     observationTimeout = null;
-  }
-  if (observationInterval) {
-    clearInterval(observationInterval);
-    observationInterval = null;
   }
   if (observer) {
     observer.disconnect();
@@ -158,10 +153,6 @@ function startObserving() {
       resetObservation();
     }
   }, 180000);
-
-  observationInterval = setInterval(() => {
-    tryCaptureLatestResponse();
-  }, 1000);
 
   observer = new MutationObserver(() => {
     tryCaptureLatestResponse();

--- a/content-scripts/deepseek.js
+++ b/content-scripts/deepseek.js
@@ -114,6 +114,12 @@ function updateChatInputValue(chatInput, text) {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === "cancelResponseObservation") {
+    resetObservation();
+    sendResponse({ received: true });
+    return true;
+  }
+
   if (message.type === "receiveQuestion") {
     resetObservation();
 
@@ -150,43 +156,7 @@ function resetObservation() {
 }
 
 async function insertQuestion(questionData) {
-  const { type, question, options, previousCorrection } = questionData;
-  let text = `Type: ${type}\nQuestion: ${question}`;
-
-  if (
-    previousCorrection &&
-    previousCorrection.question &&
-    previousCorrection.correctAnswer
-  ) {
-    text =
-      `CORRECTION FROM PREVIOUS ANSWER: For the question "${
-        previousCorrection.question
-      }", your answer was incorrect. The correct answer was: ${JSON.stringify(
-        previousCorrection.correctAnswer
-      )}\n\nNow answer this new question:\n\n` + text;
-  }
-
-  if (type === "matching") {
-    text +=
-      "\nPrompts:\n" +
-      options.prompts.map((prompt, i) => `${i + 1}. ${prompt}`).join("\n");
-    text +=
-      "\nChoices:\n" +
-      options.choices.map((choice, i) => `${i + 1}. ${choice}`).join("\n");
-    text +=
-      '\n\nPlease match each prompt with the correct choice. Set "answer" to an array of strings using the exact format \'Prompt -> Choice\'. Include one entry per prompt, use exact prompt and choice text, and use each choice at most once.';
-  } else if (type === "fill_in_the_blank") {
-    text +=
-      "\n\nThis is a fill in the blank question. If there are multiple blanks, provide answers as an array in order of appearance. For a single blank, you can provide a string.";
-  } else if (options && options.length > 0) {
-    text +=
-      "\nOptions:\n" + options.map((opt, i) => `${i + 1}. ${opt}`).join("\n");
-    text +=
-      "\n\nIMPORTANT: Your answer must EXACTLY match one of the above options. Do not include numbers in your answer. If there are periods, include them.";
-  }
-
-  text +=
-    '\n\nPlease provide your answer in JSON format with keys "answer" and "explanation". Explanations should be no more than one sentence. DO NOT acknowledge the correction in your response, only answer the new question.';
+  const text = buildPrompt(questionData);
 
   return new Promise((resolve, reject) => {
     const chatInput = findChatInput();
@@ -216,15 +186,12 @@ async function insertQuestion(questionData) {
 }
 
 function processResponse(responseText) {
-  const cleanedText = responseText
-    .replace(/[\u200B-\u200D\uFEFF]/g, "")
-    .replace(/\n\s*/g, " ")
-    .trim();
+  const cleanedText = sanitizeResponseText(responseText);
 
   try {
     const parsed = JSON.parse(cleanedText);
 
-    if (parsed && parsed.answer && !hasResponded) {
+    if (parsed && (parsed.answer !== undefined || parsed.slots) && !hasResponded) {
       hasResponded = true;
       chrome.runtime
         .sendMessage({
@@ -290,7 +257,8 @@ function checkForResponse() {
             const responseText = block.textContent.trim();
             if (
               responseText.includes("{") &&
-              responseText.includes('"answer"')
+              (responseText.includes('"answer"') ||
+                responseText.includes('"slots"'))
             ) {
               if (processResponse(responseText)) return;
             }
@@ -300,26 +268,25 @@ function checkForResponse() {
     }
 
     const messageText = message.textContent.trim();
-    const jsonMatch = messageText.match(/\{[\s\S]*?"answer"[\s\S]*?\}/);
-    if (jsonMatch) {
-      const responseText = jsonMatch[0];
+    const jsonText = findJsonObject(messageText);
+    if (jsonText && /"answer"|"slots"/.test(jsonText)) {
+      const responseText = jsonText;
       if (processResponse(responseText)) return;
     }
 
     if (Date.now() - observationStartTime > 30000) {
       try {
-        const jsonPattern = /\{[\s\S]*?"answer"[\s\S]*?"explanation"[\s\S]*?\}/;
-        const jsonMatch = messageText.match(jsonPattern);
-
-        if (jsonMatch && !hasResponded) {
-          hasResponded = true;
-          chrome.runtime.sendMessage({
-            type: "deepseekResponse",
-            response: jsonMatch[0],
-          });
-          resetObservation();
-          return true;
-        }
+        const jsonText = findJsonObject(messageText);
+        if (!jsonText || hasResponded) continue;
+        const parsed = JSON.parse(jsonText);
+        if (parsed.answer === undefined && !parsed.slots) continue;
+        hasResponded = true;
+        chrome.runtime.sendMessage({
+          type: "deepseekResponse",
+          response: jsonText,
+        });
+        resetObservation();
+        return true;
       } catch (e) {}
     }
   }
@@ -329,6 +296,7 @@ function startObserving() {
   observationStartTime = Date.now();
   observationTimeout = setTimeout(() => {
     if (!hasResponded) {
+      notifyAiResponseTimeout();
       resetObservation();
     }
   }, 180000);
@@ -346,3 +314,16 @@ function startObserving() {
 
   checkIntervalId = setInterval(checkForResponse, 1000);
 }
+
+function notifyAiResponseTimeout() {
+  try {
+    chrome.runtime.sendMessage({
+      type: "aiResponseTimeout",
+      aiModel: "deepseek",
+      reason: "DeepSeek did not produce a response within 180 seconds.",
+    });
+  } catch (error) {
+    console.error("Error notifying timeout:", error);
+  }
+}
+

--- a/content-scripts/ezto-mheducation.js
+++ b/content-scripts/ezto-mheducation.js
@@ -1,8 +1,29 @@
+// Auto-McGraw Connect content script.
+// The page snapshots fillable slots, the AI returns values by slot id, and the
+// page applies those values before navigating forward.
+
 let messageListener = null;
 let isAutomating = false;
-let lastIncorrectQuestion = null;
-let lastCorrectAnswer = null;
 let buttonAdded = false;
+let slotIdCounter = 1;
+let lastSlotMap = new Map();
+let awaitingAiResponse = false;
+let processingAiResponse = false;
+let consecutiveSetupClicks = 0;
+let consecutiveEmptySnapshots = 0;
+let consecutiveApplyErrorCycles = 0;
+let lastVisitedQuestionNumber = null;
+let answeredTabsForCurrentQuestion = new Set();
+const dropdownOptionsCache = new WeakMap();
+
+const SLOT_ATTR = "data-automcgraw-slot";
+const MAX_TEXT_LENGTH = 18000;
+const MAX_SLOTS = 120;
+const MAX_SETUP_CLICKS = 4;
+const MAX_EMPTY_SNAPSHOTS = 3;
+const DEFAULT_AI_MODEL = "chatgpt";
+
+// Message listener
 
 function setupMessageListener() {
   if (messageListener) {
@@ -10,8 +31,26 @@ function setupMessageListener() {
   }
 
   messageListener = (message, sender, sendResponse) => {
+    if (message.type === "ping") {
+      sendResponse({ received: true });
+      return true;
+    }
+
     if (message.type === "processChatGPTResponse") {
-      processChatGPTResponse(message.response);
+      handleAiResponse(message.response)
+        .then(() => {
+          sendResponse({ received: true });
+        })
+        .catch((error) => {
+          console.error("Error processing AI response:", error);
+          stopAutomation("Error processing AI response: " + error.message);
+          sendResponse({ received: false, error: error.message });
+        });
+      return true;
+    }
+
+    if (message.type === "stopAutomation") {
+      stopAutomation(message.reason || "Automation stopped");
       sendResponse({ received: true });
       return true;
     }
@@ -26,6 +65,16 @@ function setupMessageListener() {
   chrome.runtime.onMessage.addListener(messageListener);
 }
 
+// Page detection + button injection
+
+function isTopWindow() {
+  try {
+    return window.top === window;
+  } catch (error) {
+    return true;
+  }
+}
+
 function isQuizPage() {
   return (
     document.querySelector(".question") &&
@@ -35,21 +84,40 @@ function isQuizPage() {
   );
 }
 
-function checkForQuizAndAddButton() {
-  if (buttonAdded) return;
+function isConnectAssignmentPage() {
+  return Boolean(
+    document.querySelector(".question-wrap") ||
+    document.querySelector(".worksheet-wrap") ||
+    document.querySelector("iframe[title*='Assessment']") ||
+    document.querySelector(".footer__navigation--wrap") ||
+    document.querySelector(".header__exits"),
+  );
+}
 
-  const helpLink = document.querySelector(".header__help");
-  if (helpLink && isQuizPage()) {
+function checkForQuizAndAddButton() {
+  if (!isTopWindow()) return;
+
+  const existingButton = document.querySelector(".header__automcgraw");
+  if (existingButton) {
+    buttonAdded = true;
+    return;
+  }
+
+  if (buttonAdded) {
+    buttonAdded = false;
+  }
+
+  if (isQuizPage() || isConnectAssignmentPage()) {
     addAssistantButton();
     buttonAdded = true;
   }
 }
 
 function startPageObserver() {
+  if (!document.body || !isTopWindow()) return;
+
   const observer = new MutationObserver(() => {
-    if (!buttonAdded) {
-      checkForQuizAndAddButton();
-    }
+    checkForQuizAndAddButton();
   });
 
   observer.observe(document.body, {
@@ -62,76 +130,1078 @@ function startPageObserver() {
 
 function checkForQuizEnd() {
   const progressInfo = document.querySelector(".footer__progress__heading");
-
   if (progressInfo) {
-    const progressText = progressInfo.textContent;
-    const match = progressText.match(/(\d+)\s+of\s+(\d+)/);
+    const match = progressInfo.textContent.match(/(\d+)\s+of\s+(\d+)/);
     if (match) {
-      const current = parseInt(match[1]);
-      const total = parseInt(match[2]);
-      if (current > total) {
+      const current = parseInt(match[1], 10);
+      const total = parseInt(match[2], 10);
+      if (current > total) return true;
+    }
+  }
+  return false;
+}
+
+function isAssignmentSubmittedPage() {
+  return /you(?:'|’|&rsquo;)re done!\s+you submitted this assignment/i.test(
+    document.body?.innerText || "",
+  );
+}
+
+function getSelectedAiModel() {
+  return new Promise((resolve) => {
+    try {
+      chrome.storage.sync.get("aiModel", (data) => {
+        resolve(data?.aiModel || DEFAULT_AI_MODEL);
+      });
+    } catch (error) {
+      resolve(DEFAULT_AI_MODEL);
+    }
+  });
+}
+
+function getDisableAutoSubmit() {
+  return new Promise((resolve) => {
+    try {
+      chrome.storage.sync.get("disableAutoSubmit", (data) => {
+        resolve(Boolean(data?.disableAutoSubmit));
+      });
+    } catch (error) {
+      resolve(false);
+    }
+  });
+}
+
+// Top-level flow
+
+function stopAutomation(reason = "Quiz completed") {
+  const hadPendingAiResponse = awaitingAiResponse || processingAiResponse;
+
+  isAutomating = false;
+  awaitingAiResponse = false;
+  processingAiResponse = false;
+  consecutiveSetupClicks = 0;
+  consecutiveEmptySnapshots = 0;
+  lastSlotMap = new Map();
+
+  const btn = document.querySelector(".header__automcgraw--main");
+  if (btn) btn.textContent = "Ask AI";
+
+  if (hadPendingAiResponse) {
+    try {
+      chrome.runtime.sendMessage({ type: "cancelAiResponseTimeout" });
+    } catch (error) {}
+  }
+
+  if (reason) alert(`Automation stopped: ${reason}`);
+}
+
+async function checkForNextStep() {
+  if (!isAutomating) return;
+  if (awaitingAiResponse || processingAiResponse) {
+    return;
+  }
+
+  if (isAssignmentSubmittedPage()) {
+    stopAutomation("Assignment already submitted");
+    return;
+  }
+
+  await waitForConnectContentReady();
+
+  const questionNumber = getCurrentQuestionNumber() || getProgress()?.current;
+  if (questionNumber && questionNumber !== lastVisitedQuestionNumber) {
+    lastVisitedQuestionNumber = questionNumber;
+    answeredTabsForCurrentQuestion = new Set();
+  }
+
+  if (isQuizPage()) {
+    const questionData = parseQuestion();
+    if (!questionData) {
+      stopAutomation("No question found");
+      return;
+    }
+    sendToAi(questionData);
+    return;
+  }
+
+  await delay(800);
+
+  const worksheetButton = findJournalEntryWorksheetButton();
+  if (worksheetButton) {
+    clickElement(worksheetButton);
+    consecutiveEmptySnapshots = 0;
+    setTimeout(() => checkForNextStep(), 1500);
+    return;
+  }
+
+  const snapshot = await buildSlotGraphSnapshot();
+
+  if (!snapshot || !snapshot.slots.length) {
+    consecutiveEmptySnapshots++;
+
+    if (consecutiveEmptySnapshots < MAX_EMPTY_SNAPSHOTS) {
+      setTimeout(() => checkForNextStep(), 1500);
+      return;
+    }
+
+    const setupButton = findSetupRevealButton();
+    if (setupButton && consecutiveSetupClicks < MAX_SETUP_CLICKS) {
+      consecutiveSetupClicks++;
+      clickElement(setupButton);
+      consecutiveEmptySnapshots = 0;
+      setTimeout(() => checkForNextStep(), 1500);
+      return;
+    }
+
+    const advanced = await navigateForward({ filledSlots: false });
+    if (advanced) {
+      consecutiveEmptySnapshots = 0;
+      setTimeout(() => checkForNextStep(), 1500);
+      return;
+    }
+
+    stopAutomation("No answerable fields and no way to advance");
+    return;
+  }
+
+  consecutiveSetupClicks = 0;
+  consecutiveEmptySnapshots = 0;
+
+  sendToAi(snapshot.question);
+}
+
+function sendToAi(question) {
+  awaitingAiResponse = true;
+  getSelectedAiModel().then((aiModel) => {
+    chrome.runtime.sendMessage(
+      {
+        type: "sendQuestionToChatGPT",
+        question,
+        aiModel,
+      },
+      (response) => {
+        if (chrome.runtime.lastError || !response?.received) {
+          awaitingAiResponse = false;
+          stopAutomation(
+            "Could not send question to the selected AI assistant",
+          );
+        }
+      },
+    );
+  });
+}
+
+async function handleAiResponse(responseText) {
+  if (!isAutomating) {
+    return;
+  }
+
+  awaitingAiResponse = false;
+  processingAiResponse = true;
+
+  try {
+    const parsed = parseJsonResponse(responseText);
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error("AI response was not a JSON object");
+    }
+
+    if (isQuizPage()) {
+      await applyLegacySmartBookAnswer(parsed.answer);
+      await continueSmartBookAfterAnswer();
+      return;
+    }
+
+    const slotAnswers = extractSlotAnswers(parsed);
+    const { filledAny, errored } = await applySlots(slotAnswers);
+
+    if (!isAutomating) return;
+
+    if (errored && !filledAny) {
+      consecutiveApplyErrorCycles++;
+      if (consecutiveApplyErrorCycles < 3) {
+        setTimeout(() => {
+          if (isAutomating) checkForNextStep();
+        }, 1500);
+        return;
+      }
+      consecutiveApplyErrorCycles = 0;
+    } else {
+      consecutiveApplyErrorCycles = 0;
+    }
+
+    await navigateForward({ filledSlots: filledAny });
+    setTimeout(() => {
+      if (isAutomating) checkForNextStep();
+    }, 1500);
+  } finally {
+    processingAiResponse = false;
+  }
+}
+
+// JSON response parsing
+
+function parseJsonResponse(responseText) {
+  if (typeof responseText !== "string") return responseText;
+  try {
+    return JSON.parse(responseText);
+  } catch (error) {
+    const match = responseText.match(/\{[\s\S]*\}/);
+    if (match) return JSON.parse(match[0]);
+    throw error;
+  }
+}
+
+function extractSlotAnswers(parsed) {
+  if (parsed.slots && typeof parsed.slots === "object") {
+    return parsed.slots;
+  }
+  return {};
+}
+
+// Slot graph builder
+
+async function buildSlotGraphSnapshot() {
+  lastSlotMap = new Map();
+  slotIdCounter = 1;
+  clearStaleSlotAttributes();
+
+  const frames = getAccessibleDocuments();
+  frames.forEach((frame) => prepareDocumentForSnapshot(frame.doc));
+
+  const pageSections = [];
+  for (const frame of frames) {
+    const text = extractVisibleText(frame.doc);
+    if (text) pageSections.push(`${frame.label}:\n${text}`);
+  }
+  const pageText = limitText(pageSections.join("\n\n"), MAX_TEXT_LENGTH);
+
+  const promptText = extractQuestionPrompt(frames) || pageText.slice(0, 4000);
+
+  const radioGroups = new Map();
+  const candidates = [];
+
+  for (const frame of frames) {
+    const elements = getInteractiveElements(frame.doc);
+    for (const element of elements) {
+      if (candidates.length + radioGroups.size >= MAX_SLOTS) break;
+      if (isNavigationChrome(element)) continue;
+
+      const tag = element.tagName.toLowerCase();
+      const type = (element.getAttribute("type") || "").toLowerCase();
+      const role = (element.getAttribute("role") || "").toLowerCase();
+      const name = element.getAttribute("name") || "";
+
+      if (
+        (tag === "input" && (type === "radio" || type === "checkbox")) ||
+        role === "radio" ||
+        role === "checkbox"
+      ) {
+        const groupKind =
+          type === "checkbox" || role === "checkbox" ? "checkbox" : "radio";
+        const groupKey = `${frame.frame}|${groupKind}|${name || `solo-${candidates.length}-${radioGroups.size}`}`;
+        let group = radioGroups.get(groupKey);
+        if (!group) {
+          group = { kind: groupKind, name, frame, items: [] };
+          radioGroups.set(groupKey, group);
+        }
+        group.items.push(element);
+        continue;
+      }
+
+      candidates.push({ element, frame });
+    }
+  }
+
+  const slots = [];
+
+  for (const [, group] of radioGroups) {
+    const slot = describeChoiceGroup(group);
+    if (slot) {
+      lastSlotMap.set(slot.id, slot);
+      slots.push(toAiSlot(slot));
+    }
+  }
+
+  for (const { element, frame } of candidates) {
+    if (slots.length >= MAX_SLOTS) break;
+    const slot = await describeSingleSlot(element, frame);
+    if (!slot) continue;
+    lastSlotMap.set(slot.id, slot);
+    slots.push(toAiSlot(slot));
+  }
+
+  return {
+    slots,
+    pageText,
+    question: {
+      type: "connect_slot_graph",
+      prompt: promptText,
+      context: pageText,
+      slots,
+    },
+  };
+}
+
+function clearStaleSlotAttributes() {
+  for (const frame of getAccessibleDocuments()) {
+    frame.doc.querySelectorAll(`[${SLOT_ATTR}]`).forEach((el) => {
+      el.removeAttribute(SLOT_ATTR);
+    });
+  }
+}
+
+function extractQuestionPrompt(frames) {
+  const mainFrame = frames.find((f) => f.frame === "main");
+  if (mainFrame) {
+    const wrap = mainFrame.doc.querySelector(".question-wrap, .question");
+    if (wrap) {
+      return limitText(
+        normalizeWhitespace(wrap.innerText || wrap.textContent || ""),
+        4000,
+      );
+    }
+  }
+  const embedded = frames.find((f) => f.frame !== "main");
+  if (embedded) {
+    return limitText(
+      normalizeWhitespace(
+        embedded.doc.body?.innerText || embedded.doc.body?.textContent || "",
+      ),
+      4000,
+    );
+  }
+  return "";
+}
+
+async function describeSingleSlot(element, frame) {
+  const id = assignSlotId(element);
+  const tag = element.tagName.toLowerCase();
+  const dropdownLike = isDropdownLike(element);
+  const cellContext = isAnswerCell(element)
+    ? getSpreadsheetCellContext(element)
+    : null;
+
+  let kind;
+  let options = [];
+
+  if (dropdownLike || tag === "select") {
+    kind = "dropdown";
+    options = await getOptionsForControl(element, frame.doc);
+  } else if (isSpreadsheetFillCell(element)) {
+    const headerText = cellContext?.headerText || "";
+    const looksNumeric =
+      /\b(amount|debit|credit|balance|total|price|cost|quantity|qty|value)\b/i.test(
+        headerText,
+      );
+    kind = looksNumeric ? "number" : "text";
+  } else if (tag === "textarea") {
+    kind = "text";
+  } else if (tag === "input") {
+    const type = (element.getAttribute("type") || "text").toLowerCase();
+    kind = type === "number" ? "number" : "text";
+  } else if (element.isContentEditable) {
+    kind = "text";
+  } else {
+    return null;
+  }
+
+  const text = normalizeWhitespace(
+    element.innerText || element.textContent || element.value || "",
+  );
+  const label = getElementLabel(element);
+  const nearbyText = getNearbyText(element);
+  const groupHint = buildSlotHint(element, cellContext);
+
+  if (!label && !text && !nearbyText && !options.length && !cellContext) {
+    return null;
+  }
+
+  return {
+    id,
+    kind,
+    element,
+    frame: frame.frame,
+    options,
+    label: label || cellContext?.label || "",
+    text,
+    nearbyText,
+    hint: groupHint,
+    group: cellContext ? `row${cellContext.rowIndex}` : "",
+    groupRole: cellContext ? roleForCell(cellContext) : "",
+    cellContext,
+  };
+}
+
+function describeChoiceGroup(group) {
+  const items = group.items.filter((el) => isElementVisibleEnough(el));
+  if (!items.length) return null;
+
+  const id = `g${slotIdCounter++}`;
+  const choices = items.map((el) => {
+    const label = getRadioOptionLabel(el);
+    el.setAttribute(SLOT_ATTR, id);
+    return { value: label, element: el };
+  });
+  const options = choices.map((c) => c.value).filter(Boolean);
+  if (!options.length) return null;
+
+  const sample = items[0];
+  const fieldset = sample.closest(
+    "fieldset, [role='radiogroup'], .question, .question-wrap",
+  );
+  const label = fieldset
+    ? normalizeWhitespace(
+        fieldset.querySelector("legend, .question-prompt")?.innerText ||
+          fieldset.querySelector("legend, .question-prompt")?.textContent ||
+          "",
+      ) || getElementLabel(sample)
+    : getElementLabel(sample);
+  const nearbyText = getNearbyText(sample);
+
+  return {
+    id,
+    kind: group.kind === "checkbox" ? "multi_choice" : "choice",
+    element: null, // resolved per-choice via choices[].element
+    frame: group.frame.frame,
+    options,
+    choices, // private: id never sent to AI
+    label,
+    text: "",
+    nearbyText,
+    hint: label || nearbyText.slice(0, 120),
+    group: "",
+    groupRole: "",
+    cellContext: null,
+  };
+}
+
+function getRadioOptionLabel(radio) {
+  const doc = radio.ownerDocument;
+  const id = radio.id;
+  const explicitLabel = id
+    ? doc.querySelector(`label[for='${cssEscape(id)}']`)
+    : null;
+  const wrapping = radio.closest("label");
+
+  const text =
+    explicitLabel?.innerText ||
+    explicitLabel?.textContent ||
+    wrapping?.innerText ||
+    wrapping?.textContent ||
+    radio.getAttribute("aria-label") ||
+    radio.value ||
+    "";
+
+  return normalizeWhitespace(text).replace(/^[a-z]\s+/, "");
+}
+
+function assignSlotId(element) {
+  const id = `s${slotIdCounter++}`;
+  element.setAttribute(SLOT_ATTR, id);
+  return id;
+}
+
+function buildSlotHint(element, cellContext) {
+  if (cellContext) {
+    const parts = [];
+    parts.push(`row ${cellContext.rowIndex + 1}`);
+    if (cellContext.headerText) parts.push(cellContext.headerText);
+    if (cellContext.leftText) parts.push(`right of "${cellContext.leftText}"`);
+    return parts.join(", ");
+  }
+  return "";
+}
+
+function roleForCell(cellContext) {
+  const header = (cellContext.headerText || "").toLowerCase();
+  if (/debit/.test(header)) return "debit";
+  if (/credit/.test(header)) return "credit";
+  if (/account|description|item|label|name/.test(header)) return "label";
+  if (/amount|balance|total|value/.test(header)) return "amount";
+  return "";
+}
+
+function toAiSlot(slot) {
+  const out = {
+    id: slot.id,
+    kind: slot.kind,
+    label: slot.label || slot.hint || "",
+  };
+  if (slot.hint && slot.hint !== out.label) out.hint = slot.hint;
+  if (slot.group) out.group = slot.group;
+  if (slot.groupRole) out.groupRole = slot.groupRole;
+  if (slot.options?.length) out.options = slot.options;
+  if (slot.nearbyText && !out.label.includes(slot.nearbyText.slice(0, 30))) {
+    out.context = limitText(slot.nearbyText, 240);
+  }
+  return out;
+}
+
+// Navigation chrome filter (don't expose Next/Submit/Save/tabs as slots)
+
+function isNavigationChrome(element) {
+  if (isCheckMyWorkControl(element)) return true;
+  if (isAccountingNavigationControl(element)) return true;
+  if (isStaleAccountingClone(element)) return true;
+  if (element.closest(".header__automcgraw")) return true;
+
+  const tag = element.tagName.toLowerCase();
+  const role = element.getAttribute("role") || "";
+  const isTabRole = role === "tab" || element.closest("[role='tablist']");
+  if (isTabRole) return true;
+
+  if (element.closest(".footer__navigation--wrap")) return true;
+  if (element.closest(".header__exits")) return true;
+
+  const text = getControlText(element).toLowerCase();
+  if (
+    /\b(record entry|save entry|save transaction|record transaction|save & next|next part|save and next)\b/i.test(
+      text,
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    (tag === "button" || tag === "a" || role === "button") &&
+    /^(next|submit|continue|finish|done|hand in|save|cancel|close)$/i.test(
+      text.trim(),
+    )
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+// Slot executor
+
+async function applySlots(slotAnswers) {
+  let filledAny = false;
+  let appliedCount = 0;
+  let errored = false;
+  const entries = Object.entries(slotAnswers || {});
+
+  for (const [slotId, value] of entries) {
+    if (!isAutomating) break;
+    const slot = lastSlotMap.get(slotId);
+    if (!slot) {
+      continue;
+    }
+    if (value == null || (typeof value === "string" && value.trim() === "")) {
+      continue;
+    }
+
+    try {
+      await applySlot(slot, value);
+      filledAny = true;
+      appliedCount++;
+    } catch (error) {
+      errored = true;
+    }
+    await delay(200);
+  }
+
+  return { filledAny, errored };
+}
+
+async function applySlot(slot, value) {
+  if (slot.kind === "choice" || slot.kind === "multi_choice") {
+    await applyChoiceSlot(slot, value);
+    return;
+  }
+
+  const element = resolveSlotElement(slot);
+  if (!element) {
+    throw new Error(`Slot element not found: ${slot.id}`);
+  }
+
+  if (slot.kind === "dropdown") {
+    await selectElementValue(element, String(value));
+    return;
+  }
+
+  if (slot.kind === "number") {
+    await fillElement(element, formatNumberForCell(value));
+    return;
+  }
+
+  await fillElement(element, String(value));
+}
+
+async function applyChoiceSlot(slot, value) {
+  const wanted = Array.isArray(value) ? value : [value];
+  const wantedNorm = wanted.map((v) => normalizeComparable(String(v)));
+  const matchedWanted = new Set();
+
+  for (const choice of slot.choices) {
+    const choiceNorm = normalizeComparable(choice.value);
+    const matchedIndex = wantedNorm.findIndex(
+      (w) =>
+        choiceNorm === w ||
+        (choiceNorm && w && (choiceNorm.includes(w) || w.includes(choiceNorm))),
+    );
+    if (matchedIndex === -1) continue;
+    const target = resolveAnyElement(choice.element);
+    if (!target) {
+      throw new Error(`Choice element not found: ${choice.value}`);
+    }
+    clickElement(target);
+    matchedWanted.add(matchedIndex);
+    if (slot.kind === "choice") return;
+  }
+
+  const missing = wanted.filter((_, index) => !matchedWanted.has(index));
+  if (missing.length) {
+    throw new Error(`Choice option not found: ${missing.join(", ")}`);
+  }
+}
+
+function resolveSlotElement(slot) {
+  if (slot.element && slot.element.isConnected) return slot.element;
+  for (const frame of getAccessibleDocuments()) {
+    const found = frame.doc.querySelector(`[${SLOT_ATTR}='${slot.id}']`);
+    if (found) return found;
+  }
+  return null;
+}
+
+function resolveAnyElement(element) {
+  if (element?.isConnected) return element;
+  const slotId = element?.getAttribute?.(SLOT_ATTR);
+  if (!slotId) return null;
+  for (const frame of getAccessibleDocuments()) {
+    const found = frame.doc.querySelector(`[${SLOT_ATTR}='${slotId}']`);
+    if (found) return found;
+  }
+  return null;
+}
+
+function formatNumberForCell(value) {
+  if (typeof value === "number") {
+    if (value < 0) return `(${Math.abs(value)})`;
+    return String(value);
+  }
+  return String(value);
+}
+
+// Navigator (deterministic post-apply)
+
+async function navigateForward({ filledSlots }) {
+  if (!isAutomating) return false;
+
+  if (filledSlots) {
+    const saveButton = findInToolSaveButton();
+    if (saveButton) {
+      const beforeActiveNumber = getActiveTransactionNumberAcrossFrames();
+      clickElement(saveButton);
+      await waitForInToolSaveToSettle();
+      if (!isAutomating) return false;
+
+      const stillInCarousel =
+        await advanceWithinCarouselAfterSave(beforeActiveNumber);
+      if (!isAutomating) return false;
+      if (stillInCarousel) {
         return true;
       }
+
+      markActiveTabAnswered();
+    } else {
+      markActiveTabAnswered();
+    }
+  } else {
+    markActiveTabAnswered();
+  }
+
+  const nextTab = findNextRequiredTab();
+  if (nextTab) {
+    clickElement(nextTab);
+    return true;
+  }
+
+  const mainNext = findMainNextButton();
+  if (mainNext) {
+    clickElement(mainNext);
+    if (checkForQuizEnd()) {
+      stopAutomation("Quiz completed - all questions answered");
+      return true;
+    }
+    return true;
+  }
+
+  const submit = findMainSubmitButton();
+  if (submit && canAutoSubmitAssignment()) {
+    if (await getDisableAutoSubmit()) {
+      stopAutomation(
+        "Auto-submit is disabled in settings. Review your answers and submit manually.",
+      );
+      return true;
+    }
+    clickElement(submit);
+    await delay(800);
+    await confirmSubmitIfPresent();
+    stopAutomation("Assignment submitted");
+    return true;
+  }
+
+  if (submit) {
+  }
+
+  return false;
+}
+
+async function advanceWithinCarouselAfterSave(beforeActiveNumber) {
+  if (beforeActiveNumber == null) return false;
+
+  for (let i = 0; i < 10; i++) {
+    if (!isAutomating) return false;
+    const currentActive = getActiveTransactionNumberAcrossFrames();
+    if (currentActive != null && currentActive > beforeActiveNumber) {
+      const unentered = activeTransactionIsUnentered();
+      const activeText = getActiveTransactionAnnotationText();
+      return true;
+    }
+    await delay(150);
+  }
+
+  if (!isAutomating) return false;
+  for (const frame of getAccessibleDocuments()) {
+    if (frame.frame === "main") continue;
+    const arrow = findTransactionNextArrow(frame.doc);
+    if (arrow) {
+      clickElement(arrow);
+      await delay(400);
+      return true;
     }
   }
 
   return false;
 }
 
-function stopAutomation(reason = "Quiz completed") {
-  isAutomating = false;
-
-  chrome.storage.sync.get("aiModel", function (data) {
-    const currentModel = data.aiModel || "chatgpt";
-    let currentModelName = "ChatGPT";
-
-    if (currentModel === "gemini") {
-      currentModelName = "Gemini";
-    } else if (currentModel === "deepseek") {
-      currentModelName = "DeepSeek";
-    }
-
-    const btn = document.querySelector(".header__automcgraw--main");
-    if (btn) {
-      btn.textContent = `Ask ${currentModelName}`;
-    }
-  });
-
-  alert(`Automation stopped: ${reason}`);
+function getActiveTransactionNumberAcrossFrames() {
+  for (const frame of getAccessibleDocuments()) {
+    if (frame.frame === "main") continue;
+    const n = getActiveTransactionNumber(frame.doc);
+    if (n != null) return n;
+  }
+  return null;
 }
 
-function checkForNextStep() {
-  if (!isAutomating) return;
+function getActiveTransactionAnnotationText() {
+  for (const frame of getAccessibleDocuments()) {
+    if (frame.frame === "main") continue;
+    const active = getActiveTransactionButton(frame.doc);
+    if (!active) continue;
+    return getControlText(active, { preferAriaLabel: true });
+  }
+  return null;
+}
 
-  const questionData = parseQuestion();
-  if (questionData) {
-    chrome.runtime.sendMessage({
-      type: "sendQuestionToChatGPT",
-      question: questionData,
-    });
+function activeTransactionIsUnentered() {
+  for (const frame of getAccessibleDocuments()) {
+    if (frame.frame === "main") continue;
+    const active = getActiveTransactionButton(frame.doc);
+    if (!active) continue;
+    const text = getControlText(active, { preferAriaLabel: true });
+    if (/\bnot yet entered\b/i.test(text)) return true;
+    if (/\bentry entered\b/i.test(text)) return false;
+    return true;
+  }
+  return false;
+}
+
+function markActiveTabAnswered() {
+  const tab = getActiveAssessmentTabLabel();
+  if (tab) {
+    const key = normalizeComparable(tab);
+    answeredTabsForCurrentQuestion.add(key);
   } else {
-    stopAutomation("No question found or question type not supported");
   }
 }
+
+function findInToolSaveButton() {
+  for (const frame of getAccessibleDocuments()) {
+    if (frame.frame === "main") continue;
+
+    const controls = Array.from(
+      frame.doc.querySelectorAll(
+        "#saveTransation, #saveTransaction, input[type='button'], button, [role='button']",
+      ),
+    );
+    const match = controls.find((element) => {
+      if (!isElementVisibleEnough(element)) return false;
+      if (isDisabledControl(element)) return false;
+      const text = getControlText(element);
+      return /\b(record entry|save entry|record transaction|save transaction|save & next)\b/i.test(
+        text,
+      );
+    });
+    if (match) return match;
+  }
+  return null;
+}
+
+function findJournalEntryWorksheetButton() {
+  for (const frame of getAccessibleDocuments()) {
+    if (frame.frame === "main") continue;
+
+    const candidates = [
+      frame.doc.querySelector("#viewGJ"),
+      ...Array.from(
+        frame.doc.querySelectorAll(
+          "button, input[type='button'], [role='button']",
+        ),
+      ),
+    ].filter(Boolean);
+
+    const match = candidates.find((element) => {
+      if (!isElementVisibleEnough(element)) return false;
+      if (isDisabledControl(element)) return false;
+      const text = normalizeWhitespace(
+        element.value || element.innerText || element.textContent || "",
+      );
+      return /^view\s+journal\s+entry\s+worksheet$/i.test(text);
+    });
+    if (match) return match;
+  }
+  return null;
+}
+
+function findSetupRevealButton() {
+  for (const frame of getAccessibleDocuments()) {
+    const controls = Array.from(
+      frame.doc.querySelectorAll(
+        "button, input[type='button'], a[href], [role='button']",
+      ),
+    );
+    const match = controls.find((element) => {
+      if (!isElementVisibleEnough(element)) return false;
+      if (isDisabledControl(element)) return false;
+      if (isNavigationChrome(element)) return false;
+      const text = getControlText(element);
+      return (
+        /\bedit\b.*\bworksheet\b/i.test(text) ||
+        /\bopen\b.*\bworksheet\b/i.test(text) ||
+        /\badd\b.*\b(transaction|entry|row|requirement)\b/i.test(text)
+      );
+    });
+    if (match) return match;
+  }
+  return null;
+}
+
+async function waitForInToolSaveToSettle(timeout = 5000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    if (hasInToolSaveCompleted()) return true;
+    await delay(250);
+  }
+  return false;
+}
+
+function hasInToolSaveCompleted() {
+  for (const frame of getAccessibleDocuments()) {
+    if (frame.frame === "main") continue;
+
+    const bodyText = frame.doc.body?.innerText || "";
+    if (
+      /journal entry recorded successfully|entry recorded successfully/i.test(
+        bodyText,
+      )
+    ) {
+      return true;
+    }
+
+    const activeTransaction = frame.doc.querySelector(
+      ".transactionButton.active, input.active, button.active",
+    );
+    const activeText = activeTransaction
+      ? getControlText(activeTransaction, { preferAriaLabel: true })
+      : "";
+    const activeClasses = String(activeTransaction?.className || "");
+    if (
+      activeTransaction &&
+      /\bgraded\b/i.test(activeClasses) &&
+      /\bentry entered\b/i.test(activeText)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function findTransactionNextArrow(doc) {
+  return Array.from(
+    doc.querySelectorAll(
+      ".accountingtool_navigationcarousel [aria-label*='Move to next transaction'], .accountingtool_navigationcarousel .next, .accountingtool_navigationcarousel .icon-Nxt",
+    ),
+  ).find(
+    (control) => isElementVisibleEnough(control) && !isDisabledControl(control),
+  );
+}
+
+function getActiveTransactionNumber(doc) {
+  return getTransactionButtonNumber(getActiveTransactionButton(doc));
+}
+
+function getActiveTransactionButton(doc) {
+  return getTransactionButtons(doc).find(
+    (button) =>
+      button.classList.contains("active") ||
+      button.getAttribute("aria-selected") === "true",
+  );
+}
+
+function getTransactionButtons(doc) {
+  return Array.from(
+    doc.querySelectorAll(
+      ".accountingtool_navigationcarousel [role='tab'], .accountingtool_navigationcarousel input[type='button'], .accountingtool_navigationcarousel button",
+    ),
+  ).filter(
+    (button) => isElementVisibleEnough(button) && !isDisabledControl(button),
+  );
+}
+
+function getTransactionButtonNumber(button) {
+  if (!button) return null;
+  const visibleNumber = parseTransactionNumberText(button.value || "");
+  if (visibleNumber != null) return visibleNumber;
+  const refNumber = parseTransactionNumberText(
+    button.getAttribute("ref") || "",
+  );
+  if (refNumber != null) return refNumber;
+  return parseTransactionNumberText(
+    button.getAttribute("aria-label") ||
+      button.innerText ||
+      button.textContent ||
+      "",
+  );
+}
+
+function parseTransactionNumberText(value) {
+  const text = normalizeWhitespace(value || "");
+  if (!text) return null;
+  const transactionMatch = text.match(/\btransaction\s+number\s+(\d+)\b/i);
+  if (transactionMatch) return parseInt(transactionMatch[1], 10);
+  const plainMatch = text.match(/^\d+$/);
+  if (plainMatch) return parseInt(plainMatch[0], 10);
+  return null;
+}
+
+function findNextRequiredTab() {
+  const tabs = getVisibleAssessmentTabs();
+  if (!tabs.length) return null;
+
+  for (const tab of tabs) {
+    const label = normalizeComparable(getAssessmentTabLabel(tab));
+    if (!label) continue;
+    if (answeredTabsForCurrentQuestion.has(label)) continue;
+    const isActive =
+      tab.getAttribute("aria-selected") === "true" ||
+      tab.classList.contains("active") ||
+      tab.classList.contains("selected");
+    if (isActive) continue;
+    return tab;
+  }
+  return null;
+}
+
+function findMainNextButton() {
+  const candidates = [
+    document.querySelector(".footer__link--next:not([hidden])"),
+    findButtonByText(/^next$/i, ".footer__navigation--wrap"),
+  ].filter(Boolean);
+
+  return candidates.find(
+    (b) => isElementVisibleEnough(b) && !isDisabledControl(b) && !b.disabled,
+  );
+}
+
+function findMainSubmitButton() {
+  return (
+    findButtonByText(/^submit$/i, ".header__exits") ||
+    findButtonByText(/^submit$/i)
+  );
+}
+
+function canAutoSubmitAssignment() {
+  const progress = getProgress();
+  if (!progress) return false;
+  if (progress.current < progress.total) return false;
+
+  const visibleTabs = getVisibleAssessmentTabLabels().map(normalizeComparable);
+  if (visibleTabs.length) {
+    return visibleTabs.every(
+      (label) =>
+        answeredTabsForCurrentQuestion.has(label) ||
+        tabHasAnsweredIndicator(label),
+    );
+  }
+  return true;
+}
+
+function tabHasAnsweredIndicator(label) {
+  const tabs = getVisibleAssessmentTabs();
+  const tab = tabs.find(
+    (t) => normalizeComparable(getAssessmentTabLabel(t)) === label,
+  );
+  if (!tab) return false;
+  const text = (tab.innerText || tab.textContent || "").toLowerCase();
+  return /completed|answered|saved|done|recorded/.test(text);
+}
+
+async function confirmSubmitIfPresent() {
+  await delay(600);
+  const modalButton = findButtonByText(
+    /^(submit|submit assignment|hand in|yes|confirm|continue)$/i,
+    "ic-modal[aria-hidden='false'], [role='dialog'][aria-hidden='false'], .modal[aria-hidden='false']",
+  );
+  if (modalButton) clickElement(modalButton);
+}
+
+function findButtonByText(pattern, rootSelector = null) {
+  for (const frame of getAccessibleDocuments()) {
+    const roots = rootSelector
+      ? Array.from(frame.doc.querySelectorAll(rootSelector))
+      : [frame.doc];
+    const buttons = roots.flatMap((root) =>
+      Array.from(
+        root.querySelectorAll(
+          "button, [role='button'], a[href], input[type='button']",
+        ),
+      ),
+    );
+    const match = buttons.find((button) => {
+      if (!isElementVisibleEnough(button)) return false;
+      if (isDisabledControl(button)) return false;
+      const text = normalizeWhitespace(
+        button.value ||
+          button.innerText ||
+          button.textContent ||
+          button.getAttribute("aria-label") ||
+          "",
+      );
+      return pattern.test(text);
+    });
+    if (match) return match;
+  }
+  return null;
+}
+
+// SmartBook legacy quiz path
 
 function parseQuestion() {
   const questionElement = document.querySelector(".question");
-  if (!questionElement) {
-    return null;
-  }
+  if (!questionElement) return null;
 
   let questionType = "";
   let options = [];
 
   if (document.querySelector(".answers-wrap.multiple-choice")) {
     questionType = "multiple_choice";
-    const optionElements = document.querySelectorAll(
-      ".answers--mc .answer__label--mc"
-    );
-    options = Array.from(optionElements).map((el) => {
-      const textContent = el.textContent.trim();
-      return textContent.replace(/^[a-z]\s+/, "");
-    });
+    options = Array.from(
+      document.querySelectorAll(".answers--mc .answer__label--mc"),
+    ).map((el) => el.textContent.trim().replace(/^[a-z]\s+/, ""));
   } else if (document.querySelector(".answers-wrap.boolean")) {
     questionType = "true_false";
     options = ["True", "False"];
@@ -144,153 +1214,1068 @@ function parseQuestion() {
 
   let questionText = "";
   if (questionType === "fill_in_the_blank") {
-    const questionClone = questionElement.cloneNode(true);
-
-    const blankSpans = questionClone.querySelectorAll(
-      'span[aria-hidden="true"]'
-    );
-    blankSpans.forEach((span) => {
-      if (span.textContent.includes("_")) {
-        span.textContent = "[BLANK]";
-      }
+    const clone = questionElement.cloneNode(true);
+    clone.querySelectorAll('span[aria-hidden="true"]').forEach((span) => {
+      if (span.textContent.includes("_")) span.textContent = "[BLANK]";
     });
-
-    const hiddenSpans = questionClone.querySelectorAll(
-      'span[style*="position: absolute"]'
-    );
-    hiddenSpans.forEach((span) => span.remove());
-
-    questionText = questionClone.textContent.trim();
+    clone
+      .querySelectorAll('span[style*="position: absolute"]')
+      .forEach((s) => s.remove());
+    questionText = normalizeWhitespace(clone.textContent);
   } else {
-    questionText = questionElement.textContent.trim();
+    questionText = normalizeWhitespace(questionElement.textContent);
   }
 
   return {
     type: questionType,
     question: questionText,
-    options: options,
-    previousCorrection: lastIncorrectQuestion
-      ? {
-          question: lastIncorrectQuestion,
-          correctAnswer: lastCorrectAnswer,
-        }
-      : null,
+    options,
   };
 }
 
-function processChatGPTResponse(responseText) {
-  try {
-
-    const response = JSON.parse(responseText);
-    const answer = response.answer;
-
-    if (document.querySelector(".answers-wrap.multiple-choice")) {
-      handleMultipleChoiceAnswer(answer);
-    } else if (document.querySelector(".answers-wrap.boolean")) {
-      handleTrueFalseAnswer(answer);
-    } else if (document.querySelector(".answers-wrap.input-response")) {
-      handleFillInTheBlankAnswer(answer);
+async function applyLegacySmartBookAnswer(answer) {
+  if (document.querySelector(".answers-wrap.multiple-choice")) {
+    if (!handleMultipleChoiceAnswer(answer)) {
+      throw new Error("Could not match AI answer to a multiple-choice option");
     }
-
-    if (isAutomating) {
-      setTimeout(() => {
-        const nextButton = document.querySelector(
-          ".footer__link--next:not([hidden])"
-        );
-        if (
-          nextButton &&
-          !nextButton.disabled &&
-          !nextButton.classList.contains("is-disabled")
-        ) {
-          nextButton.click();
-          setTimeout(() => {
-            if (checkForQuizEnd()) {
-              stopAutomation("Quiz completed - all questions answered");
-              return;
-            }
-            checkForNextStep();
-          }, 1500);
-        } else {
-          stopAutomation("Quiz completed - no next button available");
-        }
-      }, 2000);
+  } else if (document.querySelector(".answers-wrap.boolean")) {
+    if (!handleTrueFalseAnswer(answer)) {
+      throw new Error("Could not interpret AI answer as true/false");
     }
-  } catch (e) {
-    console.error("Error processing response:", e);
-    stopAutomation("Error processing AI response: " + e.message);
+  } else if (document.querySelector(".answers-wrap.input-response")) {
+    const handled = await handleFillInTheBlankAnswer(answer);
+    if (!handled) throw new Error("Could not fill in blank with AI answer");
+  } else {
+    throw new Error("Unknown SmartBook quiz layout");
+  }
+}
+
+async function continueSmartBookAfterAnswer() {
+  await delay(1500);
+  const nextButton = document.querySelector(
+    ".footer__link--next:not([hidden])",
+  );
+  if (
+    nextButton &&
+    !nextButton.disabled &&
+    !nextButton.classList.contains("is-disabled")
+  ) {
+    clickElement(nextButton);
+    setTimeout(() => {
+      if (checkForQuizEnd()) {
+        stopAutomation("Quiz completed - all questions answered");
+        return;
+      }
+      checkForNextStep();
+    }, 1500);
+  } else {
+    stopAutomation("Quiz completed - no next button available");
   }
 }
 
 function handleMultipleChoiceAnswer(answer) {
   const radioButtons = document.querySelectorAll(
-    '.answers--mc input[type="radio"]'
+    '.answers--mc input[type="radio"]',
   );
   const labels = document.querySelectorAll(".answers--mc .answer__label--mc");
+  const answerText = getPrimaryAnswerText(answer);
+  const normalizedAnswer = normalizeComparable(answerText);
 
   for (let i = 0; i < labels.length; i++) {
     const labelText = labels[i].textContent.trim().replace(/^[a-z]\s+/, "");
+    const normalizedLabel = normalizeComparable(labelText);
 
     if (
-      labelText === answer ||
-      labelText.replace(/\.$/, "") === answer.replace(/\.$/, "") ||
-      labelText.includes(answer) ||
-      answer.includes(labelText)
+      normalizedLabel === normalizedAnswer ||
+      (normalizedLabel &&
+        normalizedAnswer &&
+        (normalizedLabel.includes(normalizedAnswer) ||
+          normalizedAnswer.includes(normalizedLabel)))
     ) {
-      radioButtons[i].click();
-      break;
+      if (!radioButtons[i]) return false;
+      clickElement(radioButtons[i]);
+      return true;
     }
   }
+  return false;
 }
 
 function handleTrueFalseAnswer(answer) {
   const buttons = document.querySelectorAll(".answer--boolean");
+  const normalizedAnswer = normalizeComparable(getPrimaryAnswerText(answer));
+  const expected =
+    answer === true || normalizedAnswer === "true"
+      ? "true"
+      : answer === false || normalizedAnswer === "false"
+        ? "false"
+        : "";
+  if (!expected) return false;
 
   for (const button of buttons) {
     const buttonSpan = button.querySelector(".answer__button--boolean");
-    if (!buttonSpan) {
-      continue;
-    }
-    
-    const fullText = buttonSpan.textContent;
-    
-    const buttonText = fullText.trim().split(",")[0].trim();
-
+    if (!buttonSpan) continue;
+    const buttonText = buttonSpan.textContent.trim().split(",")[0].trim();
     if (
-      (buttonText === "True" && (answer === "True" || answer === true)) ||
-      (buttonText === "False" && (answer === "False" || answer === false))
+      (buttonText === "True" && expected === "true") ||
+      (buttonText === "False" && expected === "false")
     ) {
-      button.click();
+      clickElement(button);
+      return true;
+    }
+  }
+  return false;
+}
+
+async function handleFillInTheBlankAnswer(answer) {
+  const inputField = document.querySelector(".answer--input__input");
+  if (!inputField) return false;
+  await fillElement(inputField, getPrimaryAnswerText(answer));
+  return true;
+}
+
+function getPrimaryAnswerText(answer) {
+  if (Array.isArray(answer)) return answer[0] == null ? "" : String(answer[0]);
+  if (answer == null) return "";
+  if (typeof answer === "object" && "answer" in answer) {
+    return getPrimaryAnswerText(answer.answer);
+  }
+  return String(answer);
+}
+
+// Page snapshot prep / DOM normalization
+
+async function waitForConnectContentReady(timeout = 5000) {
+  if (isQuizPage()) return;
+
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    const frames = getAccessibleDocuments();
+    const hasAssessmentFrame = frames.some((frame) => frame.frame !== "main");
+    const hasAnswerControls = frames.some((frame) => {
+      if (frame.frame === "main") return false;
+      return Boolean(
+        frame.doc.querySelector(
+          "td.responseCell, .groupResponse, .dropDownList, input:not([type='hidden']), textarea, select",
+        ),
+      );
+    });
+    if (!hasAssessmentFrame || hasAnswerControls) return;
+    await delay(250);
+  }
+}
+
+function getAccessibleDocuments() {
+  const docs = [
+    {
+      doc: document,
+      label: "Main page",
+      frame: "main",
+    },
+  ];
+
+  document.querySelectorAll("iframe").forEach((iframe, index) => {
+    try {
+      if (iframe.contentDocument && iframe.contentDocument.body) {
+        docs.push({
+          doc: iframe.contentDocument,
+          label:
+            `FRAME ${index}: ` +
+            (iframe.getAttribute("title") ||
+              iframe.name ||
+              iframe.id ||
+              "iframe"),
+          frame: index,
+        });
+      }
+    } catch (error) {}
+  });
+
+  return docs.filter((entry) => entry.doc && entry.doc.body);
+}
+
+function getInteractiveElements(doc) {
+  const selector = [
+    "button",
+    "a[href]",
+    "input:not([type='hidden'])",
+    "textarea",
+    "select",
+    "[contenteditable='true']",
+    "[role='button']",
+    "[role='checkbox']",
+    "[role='radio']",
+    "[role='combobox']",
+    ".dropDownList",
+    ".responseCell",
+    ".groupResponse",
+    ".responseCell[tabindex]",
+  ].join(",");
+
+  const seen = new Set();
+  return Array.from(doc.querySelectorAll(selector)).filter((element) => {
+    if (seen.has(element)) return false;
+    seen.add(element);
+    if (!isElementVisibleEnough(element)) return false;
+    if (isDisabledControl(element)) return false;
+    if (
+      element.matches("a[href]") &&
+      !normalizeWhitespace(element.textContent)
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function isAnswerCell(element) {
+  return (
+    element.tagName?.toLowerCase() === "td" &&
+    (element.classList.contains("responseCell") ||
+      element.classList.contains("groupResponse") ||
+      element.classList.contains("dropDownList"))
+  );
+}
+
+function isSpreadsheetFillCell(element) {
+  return (
+    element.tagName?.toLowerCase() === "td" &&
+    (element.classList.contains("responseCell") ||
+      element.classList.contains("groupResponse")) &&
+    !isDropdownLike(element)
+  );
+}
+
+function isDropdownLike(element) {
+  const tagName = element.tagName.toLowerCase();
+  return (
+    tagName === "select" ||
+    element.getAttribute("role") === "combobox" ||
+    element.classList.contains("dropDownList") ||
+    element.getAttribute("dropdowntype") ||
+    element.getAttribute("aria-haspopup") === "listbox"
+  );
+}
+
+function isCheckMyWorkControl(element) {
+  const text = getControlText(element);
+  return (
+    element.classList.contains("button--check-my-work") ||
+    /\bcheck my work\b/i.test(text)
+  );
+}
+
+function isAccountingNavigationControl(element) {
+  if (!element?.closest) return false;
+  const carousel = element.closest(".accountingtool_navigationcarousel");
+  if (!carousel) return false;
+
+  const text = getControlText(element, { preferAriaLabel: true });
+  return (
+    element.matches(
+      "[role='tab'], input[type='button'], button, [role='button']",
+    ) ||
+    /\bmove to (previous|next) transaction\b/i.test(text) ||
+    /\btransaction number\b/i.test(text) ||
+    /^\d+$/.test(text)
+  );
+}
+
+function isStaleAccountingClone(element) {
+  if (!element?.closest) return false;
+  if (element.closest("[data-automcgraw-hidden-duplicate='true']")) return true;
+
+  const table = element.closest("table");
+  if (table?.id === "holisticTable" && !isElementVisibleEnough(table))
+    return true;
+
+  const sheet = element.closest("#holisticSheet");
+  return Boolean(sheet && !isElementVisibleEnough(sheet));
+}
+
+function getControlText(element, options = {}) {
+  const ariaLabel = element?.getAttribute?.("aria-label") || "";
+  return normalizeWhitespace(
+    options.preferAriaLabel
+      ? ariaLabel ||
+          element.value ||
+          element.innerText ||
+          element.textContent ||
+          ""
+      : element.value ||
+          element.innerText ||
+          element.textContent ||
+          ariaLabel ||
+          "",
+  );
+}
+
+function getElementLabel(element) {
+  const doc = element.ownerDocument;
+  const id = element.id;
+  const explicitLabel = id
+    ? doc.querySelector(`label[for='${cssEscape(id)}']`)
+    : null;
+
+  return normalizeWhitespace(
+    element.getAttribute("aria-label") ||
+      element.getAttribute("title") ||
+      element.getAttribute("placeholder") ||
+      explicitLabel?.textContent ||
+      element.getAttribute("alt") ||
+      element.value ||
+      element.innerText ||
+      element.textContent ||
+      "",
+  );
+}
+
+function getNearbyText(element) {
+  const container =
+    element.closest("tr") ||
+    element.closest("fieldset") ||
+    element.closest("li") ||
+    element.closest(".question-wrap") ||
+    element.parentElement;
+  if (!container) return "";
+
+  const clone = container.cloneNode(true);
+  clone
+    .querySelectorAll(".header__automcgraw, script, style, svg")
+    .forEach((node) => node.remove());
+  return limitText(
+    normalizeWhitespace(clone.innerText || clone.textContent || ""),
+    700,
+  );
+}
+
+function getElementValue(element) {
+  if ("value" in element) return element.value || "";
+  return normalizeWhitespace(element.textContent || "");
+}
+
+function getSpreadsheetCellContext(element) {
+  const row = element.closest("tr");
+  if (!row || !element.closest("table")) return null;
+
+  const rowIndex = Array.from(row.parentElement?.children || []).indexOf(row);
+  const columnIndex = Array.from(row.children).indexOf(element);
+  const headerText = getHeaderTextForCell(element);
+  const leftCell = row.children[columnIndex - 1];
+  const leftText = normalizeWhitespace(
+    leftCell?.innerText || leftCell?.textContent || "",
+  );
+  const rightCell = row.children[columnIndex + 1];
+  const rightText = normalizeWhitespace(
+    rightCell?.innerText || rightCell?.textContent || "",
+  );
+  const rowText = normalizeWhitespace(row.innerText || row.textContent || "");
+
+  return {
+    rowIndex,
+    columnIndex,
+    label: headerText
+      ? `Row ${rowIndex + 1} ${headerText}`
+      : `Row ${rowIndex + 1} cell ${columnIndex + 1}`,
+    rowText,
+    headerText,
+    leftText,
+    rightText,
+  };
+}
+
+function getHeaderTextForCell(element) {
+  const doc = element.ownerDocument;
+  const headerIds = normalizeWhitespace(element.getAttribute("headers") || "")
+    .split(/\s+/)
+    .filter(Boolean);
+
+  return normalizeWhitespace(
+    headerIds
+      .map((id) => doc.getElementById(id))
+      .filter(Boolean)
+      .map((header) => header.innerText || header.textContent || "")
+      .join(" "),
+  );
+}
+
+function prepareDocumentForSnapshot(doc) {
+  if (!doc?.body) return;
+  closeDropdownOverlays(doc);
+  normalizeAllSpreadsheetCellClasses(doc);
+}
+
+function normalizeAllSpreadsheetCellClasses(doc) {
+  doc
+    .querySelectorAll("td.responseCell, td.groupResponse, td.dropDownList")
+    .forEach((cell) => normalizeSpreadsheetCellClasses(cell));
+}
+
+function normalizeSpreadsheetCellClasses(element) {
+  if (!element?.classList || !isAnswerCell(element)) return;
+  const uniqueClasses = uniqueStrings(
+    String(element.className || "")
+      .split(/\s+/)
+      .filter(Boolean),
+  );
+  element.className = uniqueClasses.join(" ");
+}
+
+// Dropdown options reading (open dropdown, read overlay, cache)
+
+async function getOptionsForControl(element, doc) {
+  if (element.tagName.toLowerCase() === "select") {
+    return uniqueStrings(
+      Array.from(element.options)
+        .map((option) => normalizeWhitespace(option.textContent))
+        .filter(Boolean),
+    );
+  }
+
+  if (!isDropdownLike(element)) return [];
+
+  const cacheKey = getDropdownOptionCacheKey(element);
+  const exact = getExactCachedDropdownOptions(doc, cacheKey);
+  if (exact.length) return exact;
+
+  let options = [];
+  try {
+    element.scrollIntoView({ block: "center", inline: "center" });
+    dispatchMouseSequence(element);
+    await delay(250);
+    options = readDropdownOptions(element, doc);
+  } catch (error) {
+  } finally {
+    closeDropdownOverlays(doc);
+  }
+
+  if (options.length) {
+    setCachedDropdownOptions(doc, cacheKey, options);
+    return options;
+  }
+
+  options = readDropdownOptions(element, doc);
+  if (options.length) {
+    setCachedDropdownOptions(doc, cacheKey, options);
+    return options;
+  }
+
+  return getExactCachedDropdownOptions(doc, cacheKey);
+}
+
+function getDropdownOptionCacheKey(element) {
+  return [
+    element.getAttribute("dropdownid") || "",
+    element.getAttribute("dropdowntype") || "",
+    element.getAttribute("aria-controls") || "",
+    element.closest("table")?.id || "",
+  ].join("|");
+}
+
+function getExactCachedDropdownOptions(doc, key) {
+  const docCache = dropdownOptionsCache.get(doc);
+  return docCache?.get(key) || [];
+}
+
+function setCachedDropdownOptions(doc, key, options) {
+  let docCache = dropdownOptionsCache.get(doc);
+  if (!docCache) {
+    docCache = new Map();
+    dropdownOptionsCache.set(doc, docCache);
+  }
+  const values = uniqueStrings(options);
+  docCache.set(key, values);
+}
+
+function readDropdownOptions(element, doc) {
+  const optionTexts = [];
+  const controlsId = element.getAttribute("aria-controls");
+  const listRoots = [];
+
+  if (controlsId) {
+    const controlled = doc.getElementById(controlsId);
+    if (controlled) listRoots.push(controlled);
+  }
+
+  doc.querySelectorAll(".listContainer, [role='listbox']").forEach((root) => {
+    listRoots.push(root);
+  });
+
+  for (const root of listRoots) {
+    const options = root.querySelectorAll(
+      "[role='option'], li, option, .list_content",
+    );
+    options.forEach((option) => {
+      const text = normalizeWhitespace(
+        option.innerText || option.textContent || "",
+      );
+      if (text) optionTexts.push(text);
+    });
+  }
+
+  return uniqueStrings(optionTexts);
+}
+
+function closeDropdownOverlays(doc) {
+  const win = doc.defaultView || window;
+  const targets = [
+    doc.activeElement,
+    doc.body,
+    doc.documentElement,
+    doc,
+  ].filter(Boolean);
+
+  targets.forEach((target) => {
+    ["keydown", "keyup"].forEach((type) => {
+      target.dispatchEvent(
+        new win.KeyboardEvent(type, {
+          key: "Escape",
+          code: "Escape",
+          keyCode: 27,
+          which: 27,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+  });
+
+  doc.activeElement?.blur?.();
+}
+
+// DOM mechanics: click, fill, select, spreadsheet
+
+function clickElement(element) {
+  element.scrollIntoView({ block: "center", inline: "center" });
+  element.focus?.();
+  dispatchMouseSequence(element, { includeClick: false });
+  element.click();
+}
+
+async function fillElement(element, value) {
+  const text = value == null ? "" : String(value);
+  element.scrollIntoView({ block: "center", inline: "center" });
+  element.focus?.();
+
+  if (isSpreadsheetFillCell(element)) {
+    await fillSpreadsheetCell(element, text);
+    return;
+  }
+
+  if ("value" in element) {
+    element.value = text;
+  } else if (element.isContentEditable) {
+    element.textContent = text;
+  } else {
+    throw new Error("Cannot fill a non-editable element directly");
+  }
+
+  dispatchInputEvents(element);
+}
+
+async function fillSpreadsheetCell(element, text) {
+  const doc = element.ownerDocument;
+  activateSpreadsheetCell(element);
+  await delay(220);
+
+  let editor = getSpreadsheetEditor(doc, element);
+  if (!editor) {
+    activateSpreadsheetCell(element);
+    await delay(350);
+    editor = getSpreadsheetEditor(doc, element);
+  }
+  if (!editor) {
+    dispatchEnterKey(element);
+    await delay(180);
+    editor = getSpreadsheetEditor(doc, element);
+  }
+
+  if (editor) {
+    normalizeSpreadsheetCellClasses(element);
+    editor.focus?.();
+    if ("value" in editor) {
+      editor.value = "";
+    } else {
+      editor.textContent = "";
+    }
+    dispatchInputChangeEvents(editor);
+
+    const inserted =
+      typeof doc.execCommand === "function" &&
+      doc.execCommand("insertText", false, text);
+    if (!inserted || getElementValue(editor) !== text) {
+      setElementTextValue(editor, text);
+    }
+
+    dispatchInputChangeEvents(editor);
+    dispatchEnterKey(editor);
+    await delay(220);
+    normalizeSpreadsheetCellClasses(element);
+
+    if (spreadsheetCellHasValue(element, text)) {
+      dispatchInputEvents(element);
       return;
     }
   }
-  
-  console.error("No matching button found for answer:", answer);
+
+  throw new Error(`Spreadsheet cell did not keep value: ${text}`);
 }
 
-function handleFillInTheBlankAnswer(answer) {
-  const inputField = document.querySelector(".answer--input__input");
+function activateSpreadsheetCell(element) {
+  normalizeSpreadsheetCellClasses(element);
+  element.scrollIntoView({ block: "center", inline: "center" });
+  element.focus?.();
+  element.click();
+  normalizeSpreadsheetCellClasses(element);
+}
 
-  if (inputField) {
-    let answerText = "";
+function getSpreadsheetEditor(doc, targetCell = null) {
+  const explicitEditor = [
+    ".jSheetControls_formula",
+    ".jSheetControls_editor textarea",
+    ".jSheetControls_editor input",
+  ]
+    .map((selector) => doc.querySelector(selector))
+    .find((editor) => editor && isUsableSpreadsheetInputEditor(editor));
+  if (explicitEditor) return explicitEditor;
 
-    if (Array.isArray(answer)) {
-      answerText = answer[0];
-    } else {
-      answerText = answer;
-    }
+  const activeElement = doc.activeElement;
+  if (
+    activeElement?.isContentEditable &&
+    isElementVisibleEnough(activeElement)
+  ) {
+    return activeElement;
+  }
 
-    inputField.value = answerText;
-    inputField.dispatchEvent(new Event("input", { bubbles: true }));
-    inputField.dispatchEvent(new Event("change", { bubbles: true }));
+  const editableCandidates = Array.from(
+    doc.querySelectorAll("[contenteditable='true']"),
+  ).filter((editor) => isUsableSpreadsheetEditor(editor, targetCell));
 
+  if (!editableCandidates.length) return null;
+  if (!targetCell) return editableCandidates[0];
+
+  const targetRect = targetCell.getBoundingClientRect();
+  return editableCandidates.sort((a, b) => {
+    const aRect = a.getBoundingClientRect();
+    const bRect = b.getBoundingClientRect();
+    return (
+      getRectDistanceScore(targetRect, aRect) -
+      getRectDistanceScore(targetRect, bRect)
+    );
+  })[0];
+}
+
+function isUsableSpreadsheetEditor(editor, targetCell) {
+  if (!isElementVisibleEnough(editor)) return false;
+  if (editor === targetCell) return false;
+  if (targetCell?.contains(editor)) return true;
+  const tagName = editor.tagName?.toLowerCase();
+  if (tagName === "body" || tagName === "html") return false;
+  if (editor.closest(".header__automcgraw")) return false;
+  const rect = editor.getBoundingClientRect();
+  if (rect.width > 1200 || rect.height > 300) return false;
+  return true;
+}
+
+function isUsableSpreadsheetInputEditor(editor) {
+  if (!editor) return false;
+  const tagName = editor.tagName?.toLowerCase();
+  if (!["input", "textarea"].includes(tagName)) return false;
+  if (editor.disabled || editor.readOnly) return false;
+  if (editor.closest(".header__automcgraw")) return false;
+  const style = editor.ownerDocument.defaultView?.getComputedStyle(editor);
+  if (style && (style.display === "none" || style.visibility === "hidden")) {
+    return false;
+  }
+  return true;
+}
+
+function getRectDistanceScore(a, b) {
+  const ax = a.left + a.width / 2;
+  const ay = a.top + a.height / 2;
+  const bx = b.left + b.width / 2;
+  const by = b.top + b.height / 2;
+  return Math.abs(ax - bx) + Math.abs(ay - by);
+}
+
+function setElementTextValue(element, text) {
+  if ("value" in element) {
+    element.value = text;
+  } else if (element.isContentEditable) {
+    element.textContent = text;
   } else {
-    console.error("Could not find input field for fill in the blank");
+    throw new Error("Refusing to replace non-editable element contents");
   }
 }
 
+function spreadsheetCellHasValue(element, expectedText) {
+  const actualText = normalizeWhitespace(
+    element.innerText || element.textContent || "",
+  );
+  const expected = normalizeWhitespace(expectedText);
+  const actualNumber = normalizeNumberText(actualText);
+  const expectedNumber = normalizeNumberText(expected);
+  if (actualNumber || expectedNumber) {
+    return Boolean(
+      actualNumber && expectedNumber && actualNumber === expectedNumber,
+    );
+  }
+  return normalizeComparable(actualText) === normalizeComparable(expected);
+}
+
+function normalizeNumberText(value) {
+  const text = normalizeWhitespace(value);
+  if (!/\d/.test(text)) return "";
+
+  const isParentheticalNegative = /^\(.*\)$/.test(text);
+  const numeric = text.replace(/[^\d.-]/g, "");
+  if (!numeric) return "";
+
+  const stripped = numeric.replace(/(?!^)-/g, "");
+  const signed =
+    isParentheticalNegative && !stripped.startsWith("-")
+      ? `-${stripped}`
+      : stripped;
+  const number = parseFloat(signed);
+  if (Number.isFinite(number)) return String(number);
+  return signed;
+}
+
+function dispatchMouseSequence(element, options = {}) {
+  const { includeClick = true } = options;
+  const win = element.ownerDocument.defaultView || window;
+  const rect = element.getBoundingClientRect();
+  const clientX = rect.left + Math.max(1, rect.width / 2);
+  const clientY = rect.top + Math.max(1, rect.height / 2);
+
+  ["mouseover", "mousemove", "mousedown", "mouseup"].forEach((type) => {
+    element.dispatchEvent(
+      new win.MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        view: win,
+        button: 0,
+        buttons: type === "mouseup" || type === "click" ? 0 : 1,
+        clientX,
+        clientY,
+      }),
+    );
+  });
+
+  if (!includeClick) return;
+
+  element.dispatchEvent(
+    new win.MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      view: win,
+      button: 0,
+      buttons: 0,
+      clientX,
+      clientY,
+    }),
+  );
+}
+
+function dispatchEnterKey(element) {
+  const win = element.ownerDocument.defaultView || window;
+  ["keydown", "keypress", "keyup"].forEach((type) => {
+    element.dispatchEvent(
+      new win.KeyboardEvent(type, {
+        key: "Enter",
+        code: "Enter",
+        keyCode: 13,
+        which: 13,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  });
+}
+
+async function selectElementValue(element, value) {
+  const text = value == null ? "" : String(value);
+  element.scrollIntoView({ block: "center", inline: "center" });
+  element.focus?.();
+
+  if (element.tagName.toLowerCase() === "select") {
+    selectNativeOption(element, text);
+    return;
+  }
+  await selectCustomDropdownOption(element, text);
+}
+
+function selectNativeOption(select, text) {
+  const options = Array.from(select.options);
+  const match = options.find(
+    (option) =>
+      normalizeComparable(option.textContent) === normalizeComparable(text) ||
+      normalizeComparable(option.value) === normalizeComparable(text),
+  );
+  if (!match) throw new Error(`Dropdown option not found: ${text}`);
+  select.value = match.value;
+  dispatchInputEvents(select);
+}
+
+async function selectCustomDropdownOption(element, text) {
+  if (dropdownSelectionMatches(element, text)) return;
+
+  const doc = element.ownerDocument;
+  dispatchMouseSequence(element);
+  await delay(200);
+
+  const option = findDropdownOption(doc, text);
+  if (!option) {
+    closeDropdownOverlays(doc);
+    throw new Error(`Dropdown option not found: ${text}`);
+  }
+
+  option.scrollIntoView({ block: "nearest", inline: "nearest" });
+  dispatchMouseSequence(option.querySelector("a, .list_content") || option);
+  await delay(200);
+  dispatchInputEvents(element);
+
+  if (!dropdownSelectionMatches(element, text)) {
+    const optionTarget = option.querySelector("a, .list_content") || option;
+    dispatchMouseSequence(element);
+    await delay(100);
+    dispatchMouseSequence(optionTarget);
+    await delay(200);
+    dispatchInputEvents(element);
+  }
+
+  if (!dropdownSelectionMatches(element, text)) {
+    closeDropdownOverlays(doc);
+    throw new Error(`Dropdown option did not stick: ${text}`);
+  }
+  closeDropdownOverlays(doc);
+}
+
+function findDropdownOption(doc, text) {
+  const target = normalizeComparable(text);
+  const options = Array.from(
+    doc.querySelectorAll(
+      ".listContainer [role='option'], [role='listbox'] [role='option'], .listContainer li",
+    ),
+  );
+
+  const exact = options.find(
+    (option) =>
+      normalizeComparable(option.innerText || option.textContent || "") ===
+      target,
+  );
+  if (exact) return exact;
+
+  return options.find((option) => {
+    const optionText = normalizeComparable(
+      option.innerText || option.textContent || "",
+    );
+    return isLikelyDropdownOptionMatch(target, optionText);
+  });
+}
+
+function isLikelyDropdownOptionMatch(target, optionText) {
+  if (!target || !optionText) return false;
+  const targetTokens = new Set(target.split(" ").filter(Boolean));
+  const optionTokens = optionText.split(" ").filter(Boolean);
+  if (optionTokens.length < 2) return false;
+  return optionTokens.every((token) => targetTokens.has(token));
+}
+
+function dropdownSelectionMatches(element, expectedText) {
+  const actualText =
+    element.innerText || element.textContent || getElementValue(element);
+  const actual = normalizeComparable(actualText);
+  const expected = normalizeComparable(expectedText);
+  const actualWithoutCode = normalizeDropdownDisplayText(actualText);
+  const expectedWithoutCode = normalizeDropdownDisplayText(expectedText);
+
+  return (
+    actual === expected ||
+    (actualWithoutCode && actualWithoutCode === expectedWithoutCode) ||
+    isLikelyDropdownOptionMatch(expected, actual) ||
+    isLikelyDropdownOptionMatch(actual, expected) ||
+    isLikelyDropdownOptionMatch(expectedWithoutCode, actualWithoutCode) ||
+    isLikelyDropdownOptionMatch(actualWithoutCode, expectedWithoutCode)
+  );
+}
+
+function normalizeDropdownDisplayText(value) {
+  return normalizeComparable(
+    normalizeWhitespace(value).replace(/^\d+\s*:\s*/, ""),
+  );
+}
+
+function dispatchInputEvents(element) {
+  dispatchInputChangeEvents(element);
+  const win = element.ownerDocument.defaultView || window;
+  element.dispatchEvent(new win.Event("blur", { bubbles: true }));
+}
+
+function dispatchInputChangeEvents(element) {
+  const win = element.ownerDocument.defaultView || window;
+  element.dispatchEvent(new win.Event("input", { bubbles: true }));
+  element.dispatchEvent(new win.Event("change", { bubbles: true }));
+}
+
+// Visibility / disabled checks
+
+function isElementVisibleEnough(element) {
+  const doc = element.ownerDocument;
+  const view = doc.defaultView;
+  if (!view) return true;
+
+  if (
+    element.closest(
+      "[hidden], [aria-hidden='true'], [data-automcgraw-hidden-duplicate='true']",
+    )
+  ) {
+    return false;
+  }
+
+  const style = view.getComputedStyle(element);
+  if (
+    style.display === "none" ||
+    style.visibility === "hidden" ||
+    style.opacity === "0"
+  ) {
+    return false;
+  }
+
+  if (element.hasAttribute("hidden")) return false;
+  const rect = element.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+function isDisabledControl(element) {
+  return (
+    Boolean(element.disabled) ||
+    element.getAttribute("aria-disabled") === "true" ||
+    element.classList.contains("is-disabled") ||
+    element.classList.contains("disabled") ||
+    element.classList.contains("disable")
+  );
+}
+
+// Visible-text extraction
+
+function extractVisibleText(doc) {
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = node.parentElement;
+      if (!parent) return NodeFilter.FILTER_REJECT;
+      if (parent.closest(".header__automcgraw"))
+        return NodeFilter.FILTER_REJECT;
+      if (parent.closest("script, style, noscript, svg"))
+        return NodeFilter.FILTER_REJECT;
+      if (parent.closest("[hidden], [aria-hidden='true']"))
+        return NodeFilter.FILTER_REJECT;
+      if (isAccountingNavigationText(parent)) return NodeFilter.FILTER_REJECT;
+      if (!isElementVisibleEnough(parent)) return NodeFilter.FILTER_REJECT;
+      if (!normalizeWhitespace(node.textContent))
+        return NodeFilter.FILTER_REJECT;
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  const parts = [];
+  let node = walker.nextNode();
+  while (node) {
+    parts.push(node.textContent);
+    node = walker.nextNode();
+  }
+  return limitText(normalizeWhitespace(parts.join(" ")), MAX_TEXT_LENGTH);
+}
+
+function isAccountingNavigationText(element) {
+  return Boolean(
+    element.closest(
+      ".accountingtool_navigationcarousel .control_buttons, .accountingtool_navigationcarousel .prev, .accountingtool_navigationcarousel .next, .accountingtool_navigationcarousel .icon-Prv, .accountingtool_navigationcarousel .icon-Next",
+    ),
+  );
+}
+
+// Progress + tab tracking
+
+function getProgress() {
+  const progressInfo = document.querySelector(".footer__progress__heading");
+  if (!progressInfo) return null;
+  const text = normalizeWhitespace(progressInfo.textContent);
+  const match = text.match(/(\d+)\s+of\s+(\d+)/i);
+  const totalMatch = text.match(/\bof\s+(\d+)\b/i);
+  if (!match && !totalMatch) return null;
+  const current = match ? parseInt(match[1], 10) : getCurrentQuestionNumber();
+  const total = totalMatch
+    ? parseInt(totalMatch[1], 10)
+    : parseInt(match[2], 10);
+  if (!current || !total) return null;
+  return { current, total };
+}
+
+function getCurrentQuestionNumber() {
+  const sources = [
+    document.title,
+    document.querySelector(".question__number-wrap")?.textContent,
+    document.querySelector("#question-info-holder")?.textContent,
+    document.querySelector(".footer__progress__heading")?.textContent,
+  ];
+  for (const source of sources) {
+    const match = normalizeWhitespace(source || "").match(
+      /\b(?:question|item)\s+(\d+)\b/i,
+    );
+    if (match) return parseInt(match[1], 10);
+  }
+  return null;
+}
+
+function getActiveAssessmentTabLabel() {
+  const tabs = getVisibleAssessmentTabs();
+  const activeTab =
+    tabs.find(
+      (tab) =>
+        tab.getAttribute("aria-selected") === "true" ||
+        tab.classList.contains("active") ||
+        tab.classList.contains("selected"),
+    ) || null;
+  return activeTab ? getAssessmentTabLabel(activeTab) : "";
+}
+
+function getVisibleAssessmentTabLabels() {
+  return uniqueStrings(getVisibleAssessmentTabs().map(getAssessmentTabLabel));
+}
+
+function getVisibleAssessmentTabs() {
+  const tabs = [];
+  for (const frame of getAccessibleDocuments()) {
+    if (frame.frame === "main") continue;
+    frame.doc.querySelectorAll("[role='tab'], .tab").forEach((tab) => {
+      if (!isElementVisibleEnough(tab)) return;
+      if (tab.closest(".accountingtool_navigationcarousel")) return;
+      const label = getAssessmentTabLabel(tab);
+      if (!label) return;
+      if (/^(home|accessibility|preview)$/i.test(label)) return;
+      tabs.push(tab);
+    });
+  }
+  return tabs;
+}
+
+function getAssessmentTabLabel(tab) {
+  return normalizeWhitespace(
+    tab.innerText ||
+      tab.textContent ||
+      tab.getAttribute("aria-label") ||
+      tab.getAttribute("title") ||
+      "",
+  );
+}
+
+// Assistant button
+
 function addAssistantButton() {
   const helpLink = document.querySelector(".header__help");
-  if (!helpLink) return;
+  const headerExits = document.querySelector(".header__exits");
+  const insertionTarget = helpLink || headerExits || document.body;
+  if (!insertionTarget) return;
 
   const buttonContainer = document.createElement("div");
   buttonContainer.className = "header__automcgraw";
@@ -300,145 +2285,157 @@ function addAssistantButton() {
     align-items: center;
   `;
 
-  chrome.storage.sync.get("aiModel", function (data) {
-    const aiModel = data.aiModel || "chatgpt";
-    let modelName = "ChatGPT";
+  const btn = document.createElement("button");
+  btn.textContent = "Ask AI";
+  btn.type = "button";
+  btn.className = "header__automcgraw--main";
+  btn.style.cssText = `
+    background: #fff;
+    border: 1px solid #ccc;
+    color: #333;
+    padding: 8px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    cursor: pointer;
+    border-radius: 4px 0 0 4px;
+    border-right: none;
+    height: 32px;
+    line-height: 1;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    transition: background-color 0.2s ease;
+  `;
+  btn.addEventListener(
+    "mouseenter",
+    () => (btn.style.backgroundColor = "#f5f5f5"),
+  );
+  btn.addEventListener(
+    "mouseleave",
+    () => (btn.style.backgroundColor = "#fff"),
+  );
 
-    if (aiModel === "gemini") {
-      modelName = "Gemini";
-    } else if (aiModel === "deepseek") {
-      modelName = "DeepSeek";
+  btn.addEventListener("click", () => {
+    if (isAutomating) {
+      stopAutomation("Manual stop");
+    } else {
+      const proceed = confirm(
+        "Start automation with your selected AI assistant? It will answer the current item and continue forward when possible.\n\nClick OK to begin, or Cancel to stop.",
+      );
+      if (proceed) {
+        isAutomating = true;
+        awaitingAiResponse = false;
+        processingAiResponse = false;
+        consecutiveSetupClicks = 0;
+        consecutiveEmptySnapshots = 0;
+        answeredTabsForCurrentQuestion = new Set();
+        lastVisitedQuestionNumber = null;
+        btn.textContent = "Stop Automation";
+        checkForNextStep();
+      }
     }
+  });
 
-    const btn = document.createElement("button");
-    btn.textContent = `Ask ${modelName}`;
-    btn.type = "button";
-    btn.className = "header__automcgraw--main";
-    btn.style.cssText = `
-      background: #fff;
-      border: 1px solid #ccc;
-      color: #333;
-      padding: 8px 12px;
-      font-size: 14px;
-      font-family: inherit;
-      cursor: pointer;
-      border-radius: 4px 0 0 4px;
-      border-right: none;
-      height: 32px;
-      line-height: 1;
-      text-decoration: none;
-      display: inline-flex;
-      align-items: center;
-      transition: background-color 0.2s ease;
-    `;
+  const settingsBtn = document.createElement("button");
+  settingsBtn.type = "button";
+  settingsBtn.className = "header__automcgraw--settings";
+  settingsBtn.title = "Auto-McGraw Settings";
+  settingsBtn.setAttribute("aria-label", "Auto-McGraw Settings");
+  settingsBtn.style.cssText = `
+    background: #fff;
+    border: 1px solid #ccc;
+    color: #333;
+    padding: 8px 10px;
+    font-size: 14px;
+    cursor: pointer;
+    border-radius: 0 4px 4px 0;
+    height: 32px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s ease;
+  `;
+  settingsBtn.addEventListener(
+    "mouseenter",
+    () => (settingsBtn.style.backgroundColor = "#f5f5f5"),
+  );
+  settingsBtn.addEventListener(
+    "mouseleave",
+    () => (settingsBtn.style.backgroundColor = "#fff"),
+  );
+  settingsBtn.innerHTML = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="3"></circle>
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06-.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+    </svg>
+  `;
+  settingsBtn.addEventListener("click", () => {
+    chrome.runtime.sendMessage({ type: "openSettings" });
+  });
 
-    btn.addEventListener("mouseenter", () => {
-      btn.style.backgroundColor = "#f5f5f5";
-    });
+  buttonContainer.appendChild(btn);
+  buttonContainer.appendChild(settingsBtn);
 
-    btn.addEventListener("mouseleave", () => {
-      btn.style.backgroundColor = "#fff";
-    });
-
-    btn.addEventListener("click", () => {
-      if (isAutomating) {
-        stopAutomation("Manual stop");
-      } else {
-        const proceed = confirm(
-          "Start quiz automation? The automation will stop automatically when the quiz ends.\n\nClick OK to begin, or Cancel to stop."
-        );
-        if (proceed) {
-          isAutomating = true;
-          btn.textContent = "Stop Automation";
-          checkForNextStep();
-        }
-      }
-    });
-
-    const settingsBtn = document.createElement("button");
-    settingsBtn.type = "button";
-    settingsBtn.className = "header__automcgraw--settings";
-    settingsBtn.title = "Auto-McGraw Settings";
-    settingsBtn.setAttribute("aria-label", "Auto-McGraw Settings");
-    settingsBtn.style.cssText = `
-      background: #fff;
-      border: 1px solid #ccc;
-      color: #333;
-      padding: 8px 10px;
-      font-size: 14px;
-      cursor: pointer;
-      border-radius: 0 4px 4px 0;
-      height: 32px;
-      line-height: 1;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      transition: background-color 0.2s ease;
-    `;
-
-    settingsBtn.addEventListener("mouseenter", () => {
-      settingsBtn.style.backgroundColor = "#f5f5f5";
-    });
-
-    settingsBtn.addEventListener("mouseleave", () => {
-      settingsBtn.style.backgroundColor = "#fff";
-    });
-
-    settingsBtn.innerHTML = `
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="12" cy="12" r="3"></circle>
-        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06-.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
-      </svg>
-    `;
-
-    settingsBtn.addEventListener("click", () => {
-      chrome.runtime.sendMessage({ type: "openSettings" });
-    });
-
-    buttonContainer.appendChild(btn);
-    buttonContainer.appendChild(settingsBtn);
+  if (helpLink && helpLink.parentNode) {
     helpLink.parentNode.insertBefore(buttonContainer, helpLink);
-
-    chrome.storage.onChanged.addListener((changes) => {
-      if (changes.aiModel) {
-        const newModel = changes.aiModel.newValue;
-        let newModelName = "ChatGPT";
-
-        if (newModel === "gemini") {
-          newModelName = "Gemini";
-        } else if (newModel === "deepseek") {
-          newModelName = "DeepSeek";
-        }
-
-        if (!isAutomating) {
-          btn.textContent = `Ask ${newModelName}`;
-        }
-      }
-    });
-  });
+  } else if (headerExits) {
+    headerExits.insertBefore(buttonContainer, headerExits.firstChild);
+  } else {
+    document.body.appendChild(buttonContainer);
+  }
 }
 
-function waitForElement(selector, timeout = 5000) {
-  return new Promise((resolve, reject) => {
-    const startTime = Date.now();
-    const interval = setInterval(() => {
-      const el = document.querySelector(selector);
-      if (el) {
-        clearInterval(interval);
-        resolve(el);
-      } else if (Date.now() - startTime > timeout) {
-        clearInterval(interval);
-        reject(new Error("Element not found: " + selector));
-      }
-    }, 100);
-  });
+// Utilities
+
+function normalizeWhitespace(value) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
+
+function normalizeComparable(value) {
+  return normalizeWhitespace(value)
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
+function uniqueStrings(values) {
+  const seen = new Set();
+  const result = [];
+  values.forEach((value) => {
+    const text = normalizeWhitespace(value);
+    const key = normalizeComparable(text);
+    if (!text || seen.has(key)) return;
+    seen.add(key);
+    result.push(text);
+  });
+  return result;
+}
+
+function limitText(text, maxLength) {
+  const value = normalizeWhitespace(text);
+  if (value.length <= maxLength) return value;
+  return value.slice(0, maxLength) + "...";
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function cssEscape(value) {
+  if (window.CSS && typeof window.CSS.escape === "function") {
+    return window.CSS.escape(value);
+  }
+  return String(value).replace(/[^a-zA-Z0-9_-]/g, (ch) => `\\${ch}`);
+}
+
+// Boot
 
 setupMessageListener();
 startPageObserver();
 
 if (isAutomating) {
-  setTimeout(() => {
-    checkForNextStep();
-  }, 1000);
+  setTimeout(() => checkForNextStep(), 1000);
 }

--- a/content-scripts/ezto-mheducation.js
+++ b/content-scripts/ezto-mheducation.js
@@ -678,7 +678,6 @@ function isNavigationChrome(element) {
 
 async function applySlots(slotAnswers) {
   let filledAny = false;
-  let appliedCount = 0;
   let errored = false;
   const entries = Object.entries(slotAnswers || {});
 
@@ -695,7 +694,6 @@ async function applySlots(slotAnswers) {
     try {
       await applySlot(slot, value);
       filledAny = true;
-      appliedCount++;
     } catch (error) {
       errored = true;
     }
@@ -844,9 +842,6 @@ async function navigateForward({ filledSlots }) {
     return true;
   }
 
-  if (submit) {
-  }
-
   return false;
 }
 
@@ -857,8 +852,6 @@ async function advanceWithinCarouselAfterSave(beforeActiveNumber) {
     if (!isAutomating) return false;
     const currentActive = getActiveTransactionNumberAcrossFrames();
     if (currentActive != null && currentActive > beforeActiveNumber) {
-      const unentered = activeTransactionIsUnentered();
-      const activeText = getActiveTransactionAnnotationText();
       return true;
     }
     await delay(150);
@@ -2274,8 +2267,7 @@ function getAssessmentTabLabel(tab) {
 function addAssistantButton() {
   const helpLink = document.querySelector(".header__help");
   const headerExits = document.querySelector(".header__exits");
-  const insertionTarget = helpLink || headerExits || document.body;
-  if (!insertionTarget) return;
+  if (!helpLink && !headerExits && !document.body) return;
 
   const buttonContainer = document.createElement("div");
   buttonContainer.className = "header__automcgraw";

--- a/content-scripts/ezto-mheducation.js
+++ b/content-scripts/ezto-mheducation.js
@@ -348,8 +348,8 @@ function parseJsonResponse(responseText) {
   try {
     return JSON.parse(responseText);
   } catch (error) {
-    const match = responseText.match(/\{[\s\S]*\}/);
-    if (match) return JSON.parse(match[0]);
+    const extracted = findJsonObject(responseText);
+    if (extracted) return JSON.parse(extracted);
     throw error;
   }
 }
@@ -645,7 +645,6 @@ function toAiSlot(slot) {
 function isNavigationChrome(element) {
   if (isCheckMyWorkControl(element)) return true;
   if (isAccountingNavigationControl(element)) return true;
-  if (isStaleAccountingClone(element)) return true;
   if (element.closest(".header__automcgraw")) return true;
 
   const tag = element.tagName.toLowerCase();
@@ -1473,18 +1472,6 @@ function isAccountingNavigationControl(element) {
     /\btransaction number\b/i.test(text) ||
     /^\d+$/.test(text)
   );
-}
-
-function isStaleAccountingClone(element) {
-  if (!element?.closest) return false;
-  if (element.closest("[data-automcgraw-hidden-duplicate='true']")) return true;
-
-  const table = element.closest("table");
-  if (table?.id === "holisticTable" && !isElementVisibleEnough(table))
-    return true;
-
-  const sheet = element.closest("#holisticSheet");
-  return Boolean(sheet && !isElementVisibleEnough(sheet));
 }
 
 function getControlText(element, options = {}) {

--- a/content-scripts/ezto-mheducation.js
+++ b/content-scripts/ezto-mheducation.js
@@ -295,6 +295,9 @@ async function handleAiResponse(responseText) {
   if (!isAutomating) {
     return;
   }
+  if (processingAiResponse) {
+    return;
+  }
 
   awaitingAiResponse = false;
   processingAiResponse = true;
@@ -908,7 +911,6 @@ function markActiveTabAnswered() {
   if (tab) {
     const key = normalizeComparable(tab);
     answeredTabsForCurrentQuestion.add(key);
-  } else {
   }
 }
 

--- a/content-scripts/gemini.js
+++ b/content-scripts/gemini.js
@@ -5,6 +5,12 @@ let observationTimeout = null;
 let observer = null;
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === "cancelResponseObservation") {
+    resetObservation();
+    sendResponse({ received: true });
+    return true;
+  }
+
   if (message.type === "receiveQuestion") {
     resetObservation();
 
@@ -53,43 +59,7 @@ function waitForIdle(timeout = 120000) {
 }
 
 async function insertQuestion(questionData) {
-  const { type, question, options, previousCorrection } = questionData;
-  let text = `Type: ${type}\nQuestion: ${question}`;
-
-  if (
-    previousCorrection &&
-    previousCorrection.question &&
-    previousCorrection.correctAnswer
-  ) {
-    text =
-      `CORRECTION FROM PREVIOUS ANSWER: For the question "${
-        previousCorrection.question
-      }", your answer was incorrect. The correct answer was: ${JSON.stringify(
-        previousCorrection.correctAnswer
-      )}\n\nNow answer this new question:\n\n` + text;
-  }
-
-  if (type === "matching") {
-    text +=
-      "\nPrompts:\n" +
-      options.prompts.map((prompt, i) => `${i + 1}. ${prompt}`).join("\n");
-    text +=
-      "\nChoices:\n" +
-      options.choices.map((choice, i) => `${i + 1}. ${choice}`).join("\n");
-    text +=
-      '\n\nPlease match each prompt with the correct choice. Set "answer" to an array of strings using the exact format \'Prompt -> Choice\'. Include one entry per prompt, use exact prompt and choice text, and use each choice at most once.';
-  } else if (type === "fill_in_the_blank") {
-    text +=
-      "\n\nThis is a fill in the blank question. If there are multiple blanks, provide answers as an array in order of appearance. For a single blank, you can provide a string.";
-  } else if (options && options.length > 0) {
-    text +=
-      "\nOptions:\n" + options.map((opt, i) => `${i + 1}. ${opt}`).join("\n");
-    text +=
-       "\n\nIMPORTANT: Your answer must EXACTLY match the above options. Do not include numbers in your answer. If there are periods, include them. If there are multiple selections, include all of the correct selections.";
-  }
-
-  text +=
-    '\n\nPlease provide your answer in JSON format with keys "answer" and "explanation". Explanations should be no more than one sentence. DO NOT acknowledge the correction in your response, only answer the new question.';
+  const text = buildPrompt(questionData);
 
   return new Promise((resolve, reject) => {
     waitForIdle()
@@ -98,7 +68,7 @@ async function insertQuestion(questionData) {
         if (inputArea) {
           setTimeout(() => {
             inputArea.focus();
-            inputArea.innerHTML = `<p>${text}</p>`;
+            inputArea.innerHTML = `<p>${escapeHtml(text)}</p>`;
             inputArea.dispatchEvent(new Event("input", { bubbles: true }));
 
             setTimeout(() => {
@@ -120,10 +90,18 @@ async function insertQuestion(questionData) {
   });
 }
 
+function escapeHtml(text) {
+  return String(text || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 function startObserving() {
   observationStartTime = Date.now();
   observationTimeout = setTimeout(() => {
     if (!hasResponded) {
+      notifyAiResponseTimeout();
       resetObservation();
     }
   }, 180000);
@@ -154,14 +132,11 @@ function startObserving() {
       if (jsonMatch) responseText = jsonMatch[0];
     }
 
-    responseText = responseText
-      .replace(/[\u200B-\u200D\uFEFF]/g, "")
-      .replace(/\n\s*/g, " ")
-      .trim();
+    responseText = sanitizeResponseText(responseText);
 
     try {
       const parsed = JSON.parse(responseText);
-      if (parsed.answer && !hasResponded) {
+      if ((parsed.answer !== undefined || parsed.slots) && !hasResponded) {
         hasResponded = true;
         chrome.runtime
           .sendMessage({
@@ -183,18 +158,16 @@ function startObserving() {
       if (!isGenerating && Date.now() - observationStartTime > 30000) {
         const responseText = latestMessage.textContent.trim();
         try {
-          const jsonPattern =
-            /\{[\s\S]*?"answer"[\s\S]*?"explanation"[\s\S]*?\}/;
-          const jsonMatch = responseText.match(jsonPattern);
-
-          if (jsonMatch && !hasResponded) {
-            hasResponded = true;
-            chrome.runtime.sendMessage({
-              type: "geminiResponse",
-              response: jsonMatch[0],
-            });
-            resetObservation();
-          }
+          const jsonText = findJsonObject(responseText);
+          if (!jsonText || hasResponded) return;
+          const parsed = JSON.parse(jsonText);
+          if (parsed.answer === undefined && !parsed.slots) return;
+          hasResponded = true;
+          chrome.runtime.sendMessage({
+            type: "geminiResponse",
+            response: jsonText,
+          });
+          resetObservation();
         } catch (e) {}
       }
     }
@@ -206,3 +179,16 @@ function startObserving() {
     characterData: true,
   });
 }
+
+function notifyAiResponseTimeout() {
+  try {
+    chrome.runtime.sendMessage({
+      type: "aiResponseTimeout",
+      aiModel: "gemini",
+      reason: "Gemini did not produce a response within 180 seconds.",
+    });
+  } catch (error) {
+    console.error("Error notifying timeout:", error);
+  }
+}
+

--- a/content-scripts/gemini.js
+++ b/content-scripts/gemini.js
@@ -127,9 +127,8 @@ function startObserving() {
     }
 
     if (!responseText) {
-      responseText = latestMessage.textContent.trim();
-      const jsonMatch = responseText.match(/\{[\s\S]*\}/);
-      if (jsonMatch) responseText = jsonMatch[0];
+      const extracted = findJsonObject(latestMessage.textContent);
+      if (extracted) responseText = extracted;
     }
 
     responseText = sanitizeResponseText(responseText);

--- a/content-scripts/shared/ai-prompt.js
+++ b/content-scripts/shared/ai-prompt.js
@@ -1,0 +1,102 @@
+function buildPrompt(questionData) {
+  if (questionData.type === "connect_slot_graph") {
+    return buildSlotGraphPrompt(questionData);
+  }
+
+  const { type, question, options, previousCorrection } = questionData;
+  let text = `Type: ${type}\nQuestion: ${question}`;
+
+  if (
+    previousCorrection &&
+    previousCorrection.question &&
+    previousCorrection.correctAnswer
+  ) {
+    text =
+      `CORRECTION FROM PREVIOUS ANSWER: For the question "${
+        previousCorrection.question
+      }", your answer was incorrect. The correct answer was: ${JSON.stringify(
+        previousCorrection.correctAnswer,
+      )}\n\nNow answer this new question:\n\n` + text;
+  }
+
+  if (type === "matching") {
+    text +=
+      "\nPrompts:\n" +
+      options.prompts.map((prompt, i) => `${i + 1}. ${prompt}`).join("\n");
+    text +=
+      "\nChoices:\n" +
+      options.choices.map((choice, i) => `${i + 1}. ${choice}`).join("\n");
+    text +=
+      "\n\nPlease match each prompt with the correct choice. Set \"answer\" to an array of strings using the exact format 'Prompt -> Choice'. Include one entry per prompt, use exact prompt and choice text, and use each choice at most once.";
+  } else if (type === "fill_in_the_blank") {
+    text +=
+      "\n\nThis is a fill in the blank question. If there are multiple blanks, provide answers as an array in order of appearance. For a single blank, you can provide a string.";
+  } else if (options && options.length > 0) {
+    text +=
+      "\nOptions:\n" + options.map((opt, i) => `${i + 1}. ${opt}`).join("\n");
+    text +=
+      "\n\nIMPORTANT: Your answer must EXACTLY match one of the above options. Do not include numbers in your answer. If there are periods, include them.";
+  }
+
+  text +=
+    '\n\nPlease provide your answer in JSON format with keys "answer" and "explanation". Explanations should be no more than one sentence. DO NOT acknowledge the correction in your response, only answer the new question.';
+
+  return text;
+}
+
+function buildSlotGraphPrompt(questionData) {
+  const { prompt, context, slots } = questionData;
+  const slotList = Array.isArray(slots) ? slots : [];
+
+  let text = `Question / page prompt:\n${prompt || ""}`;
+
+  if (context && context !== prompt) {
+    text += `\n\nFull page context:\n${context}`;
+  }
+
+  text += `\n\nFillable slots (you must return a value for each slot you can answer):\n${JSON.stringify(
+    slotList,
+    null,
+    2,
+  )}`;
+
+  text += `\n\nReturn JSON of the form: {"slots": {"<slot id>": <value>, ...}, "explanation": "<one sentence>"}`;
+  text += `\n\nReturn only the raw JSON object - no markdown fences, no acknowledgements, no prose outside the JSON.`;
+  text += `\n\nRules:`;
+  text += `\n- Use the exact slot ids from the slots list as the keys.`;
+  text += `\n- For dropdown slots, the value must be EXACTLY one of the option strings shown in that slot's "options".`;
+  text += `\n- For choice / boolean slots (single selection), the value is the exact option string you want to pick.`;
+  text += `\n- For multi_choice slots, the value is an array of exact option strings.`;
+  text += `\n- For number slots, write the number as you would type it. For NEGATIVE numbers in McGraw's accounting cells, use parentheses, e.g. "(4,976)" - McGraw stores negatives that way.`;
+  text += `\n- For text slots, write the natural-language answer as a string.`;
+  text += `\n- If a slot has no answer (truly blank cell), omit it or set its value to null. Do not invent values.`;
+  text += `\n- Use slot "hint", "group", and "groupRole" to keep paired cells (label/amount, debit/credit, row 1/row 2) consistent.`;
+  text += `\n- Do NOT emit any other keys (no "actions", no selectors). The page knows how to apply each slot.`;
+
+  return text;
+}
+
+function sanitizeResponseText(text) {
+  return String(text || "")
+    .replace(/[\u200B-\u200D\uFEFF]/g, "")
+    .trim();
+}
+
+function looksLikeJsonResponse(text) {
+  return (
+    text.startsWith("{") && text.endsWith("}") && /"answer"|"slots"/.test(text)
+  );
+}
+
+function findJsonObject(text) {
+  const value = sanitizeResponseText(text);
+  if (looksLikeJsonResponse(value)) return value;
+
+  const firstBrace = value.indexOf("{");
+  const lastBrace = value.lastIndexOf("}");
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    return "";
+  }
+
+  return value.slice(firstBrace, lastBrace + 1);
+}

--- a/manifest.json
+++ b/manifest.json
@@ -34,15 +34,24 @@
     },
     {
       "matches": ["https://chatgpt.com/*"],
-      "js": ["content-scripts/chatgpt.js"]
+      "js": [
+        "content-scripts/shared/ai-prompt.js",
+        "content-scripts/chatgpt.js"
+      ]
     },
     {
       "matches": ["https://gemini.google.com/*"],
-      "js": ["content-scripts/gemini.js"]
+      "js": [
+        "content-scripts/shared/ai-prompt.js",
+        "content-scripts/gemini.js"
+      ]
     },
     {
       "matches": ["https://chat.deepseek.com/*"],
-      "js": ["content-scripts/deepseek.js"]
+      "js": [
+        "content-scripts/shared/ai-prompt.js",
+        "content-scripts/deepseek.js"
+      ]
     }
   ],
   "web_accessible_resources": [

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,6 @@
     "https://chatgpt.com/*",
     "https://gemini.google.com/*",
     "https://chat.deepseek.com/*",
-    "https://deepseek.chat/*",
     "https://api.github.com/*"
   ],
   "background": {
@@ -56,16 +55,6 @@
         "content-scripts/shared/ai-prompt.js",
         "content-scripts/deepseek.js"
       ]
-    }
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": [
-        "popup/settings.html",
-        "popup/settings.css",
-        "popup/settings.js"
-      ],
-      "matches": ["<all_urls>"]
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
   "host_permissions": [
     "https://learning.mheducation.com/*",
     "https://ezto.mheducation.com/*",
+    "https://newconnect.mheducation.com/*",
     "https://chatgpt.com/*",
     "https://gemini.google.com/*",
     "https://chat.deepseek.com/*",
@@ -29,7 +30,10 @@
       "js": ["content-scripts/mheducation.js"]
     },
     {
-      "matches": ["https://ezto.mheducation.com/*"],
+      "matches": [
+        "https://ezto.mheducation.com/*",
+        "https://newconnect.mheducation.com/*"
+      ],
       "js": ["content-scripts/ezto-mheducation.js"]
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,10 @@
         "https://ezto.mheducation.com/*",
         "https://newconnect.mheducation.com/*"
       ],
-      "js": ["content-scripts/ezto-mheducation.js"]
+      "js": [
+        "content-scripts/shared/ai-prompt.js",
+        "content-scripts/ezto-mheducation.js"
+      ]
     },
     {
       "matches": ["https://chatgpt.com/*"],

--- a/popup/settings.html
+++ b/popup/settings.html
@@ -141,6 +141,19 @@
             </div>
           </label>
         </div>
+        <div class="feature-toggle">
+          <label class="toggle-container">
+            <input type="checkbox" id="disable-auto-submit-toggle" />
+            <span class="toggle-slider"></span>
+            <div class="toggle-label">
+              <h3>Disable Auto-Submit</h3>
+              <p>
+                Stop automation at the final item of a Connect assignment
+                instead of clicking Submit. You can review and submit manually.
+              </p>
+            </div>
+          </label>
+        </div>
       </div>
 
       <div class="settings-section">

--- a/popup/settings.js
+++ b/popup/settings.js
@@ -71,12 +71,17 @@ document.addEventListener("DOMContentLoaded", function () {
   const doubleCreditToggle = document.getElementById("double-credit-toggle");
   const randomConfidenceToggle = document.getElementById("random-confidence-toggle");
   const pauseBeforeSubmitToggle = document.getElementById("pause-before-submit-toggle");
+  const disableAutoSubmitToggle = document.getElementById("disable-auto-submit-toggle");
 
-  chrome.storage.sync.get(["doubleCreditMode", "randomConfidence", "pauseBeforeSubmit"], function (data) {
-    doubleCreditToggle.checked = data.doubleCreditMode || false;
-    randomConfidenceToggle.checked = data.randomConfidence || false;
-    pauseBeforeSubmitToggle.checked = data.pauseBeforeSubmit || false;
-  });
+  chrome.storage.sync.get(
+    ["doubleCreditMode", "randomConfidence", "pauseBeforeSubmit", "disableAutoSubmit"],
+    function (data) {
+      doubleCreditToggle.checked = data.doubleCreditMode || false;
+      randomConfidenceToggle.checked = data.randomConfidence || false;
+      pauseBeforeSubmitToggle.checked = data.pauseBeforeSubmit || false;
+      disableAutoSubmitToggle.checked = data.disableAutoSubmit || false;
+    }
+  );
 
   doubleCreditToggle.addEventListener("change", function () {
     chrome.storage.sync.set({ doubleCreditMode: this.checked });
@@ -88,6 +93,10 @@ document.addEventListener("DOMContentLoaded", function () {
 
   pauseBeforeSubmitToggle.addEventListener("change", function () {
     chrome.storage.sync.set({ pauseBeforeSubmit: this.checked });
+  });
+
+  disableAutoSubmitToggle.addEventListener("change", function () {
+    chrome.storage.sync.set({ disableAutoSubmit: this.checked });
   });
 
   function checkModelAvailability(currentModel) {


### PR DESCRIPTION
## Summary

Adds automation support for McGraw Hill Connect assignments on `ezto.mheducation.com` and `newconnect.mheducation.com`.

Connect pages are handled with a slot-based prompt: the content script collects the answerable fields on the page, sends those slots to the selected AI assistant, then applies the returned values back to the matching fields. The navigation flow also handles common Connect steps such as worksheet entry, accounting transaction pages, required tabs, Next, and final Submit.

This keeps the existing SmartBook flow in place and shares the AI prompt/response helpers across ChatGPT, Gemini, and DeepSeek. Also includes some refactors but if this is out-of-scope let me know and I can revert those.

## Changes

- Add `newconnect.mheducation.com` permissions and content-script matching
- Add a shared AI prompt builder and JSON response helpers
- Route AI tabs through a shared model config in the background script
- Add Connect slot extraction and answer application in `ezto-mheducation.js`
- Add timeout/cancel handling between AI tabs and the MHE tab
- Add a “Disable Auto-Submit” setting so users can review before submitting

## Testing

- [x] Load the unpacked extension in Chrome
- [x] Verify the settings popup opens and saves the new Disable Auto-Submit toggle
- [x] Run a SmartBook assignment as a regression check
- [x] Run a Connect assignment with dropdowns, text/number fields, required tabs, and accounting worksheet entries
- [x] Verify Disable Auto-Submit stops before final submission
- [x] Verify automation stops cleanly if the AI assistant does not respond
